### PR TITLE
fix: preserve the caller's $total when caching is disabled

### DIFF
--- a/src/Traits/Buildable.php
+++ b/src/Traits/Buildable.php
@@ -183,7 +183,7 @@ trait Buildable
         $total = null,
     ) {
         if (! $this->isCachable()) {
-            return parent::paginate($perPage, $columns, $pageName, $page);
+            return parent::paginate($perPage, $columns, $pageName, $page, $total);
         }
 
         $page = $page ?: Paginator::resolveCurrentPage($pageName);

--- a/tests/Integration/CachedBuilder/PaginateTest.php
+++ b/tests/Integration/CachedBuilder/PaginateTest.php
@@ -189,4 +189,13 @@ class PaginateTest extends IntegrationTestCase
             "Paginator should not retain the original cached domain"
         );
     }
+
+    public function testUncachedPaginationHonorsProvidedTotal()
+    {
+        $authors = (new Author)
+            ->disableModelCaching()
+            ->paginate(3, ["*"], "page", 1, 999);
+
+        $this->assertEquals(999, $authors->total());
+    }
 }


### PR DESCRIPTION
## The bug

`Buildable::paginate()` accepts `$total`, but drops it when it short-circuits for a non-cachable builder:

```php
if (! $this->isCachable()) {
    return parent::paginate($perPage, $columns, $pageName, $page); // $total lost
}
```

Eloquent then runs the `count(*)` the caller passed the total precisely to avoid, and the paginator reports the queried total instead of the given one.

The cachable branch is fine — it forwards `func_get_args()`, so `$total` survives there. The result is that passing a total works while the model cache is enabled and silently regresses on any builder that resolves as non-cachable (an explicit `disableModelCaching()`, an eager load of a non-cachable model, the cooldown path, …).

This matters where the count is expensive. On a large partitioned table we obtain the total once — cheaply, or from our own cache — and hand it to `paginate()`; today that only holds while the query happens to be cachable, and the reappearing `count(*)` costs 90–190 ms per request.

## The fix

Forward `$total`. One line.

## Not changed

`CachesOneOrManyThrough::paginate()` has the same shape, but `HasOneOrManyThrough::paginate()` and `BelongsToMany::paginate()` take no `$total` parameter in Laravel itself, so forwarding it there would be a no-op. Left alone.

## Test

`PaginateTest::testUncachedPaginationHonorsProvidedTotal` — fails on master (`3` != `999`), passes with the fix.
