### PR TITLE
fix: don't crash building join tags for expression join tables

### DIFF
--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -78,6 +78,19 @@ class CacheTags
             ->map(function ($join) {
                 $table = $join->table;
 
+                // `joinSub()` — and anything else joining a raw expression —
+                // stores an Expression here instead of a table name. There is
+                // no table to tag, and the stripos() below raises a TypeError
+                // on it. Eloquent's `ofMany()` relations build exactly such a
+                // join, so any query whose joins are already materialized when
+                // the tags are made (an explicit `joinSub()`, or an `ofMany()`
+                // query compiled earlier) fails there. The subquery selects
+                // from the related model's own table, which is already tagged
+                // through that model, so skipping it loses no invalidation.
+                if (! is_string($table)) {
+                    return null;
+                }
+
                 // Strip alias (e.g. "products as p" -> "products")
                 if (stripos($table, ' as ') !== false) {
                     $table = trim(explode(' as ', strtolower($table))[0]);
@@ -85,6 +98,7 @@ class CacheTags
 
                 return $table;
             })
+            ->filter()
             ->map(function ($table) use ($prefix) {
                 return $prefix . (new Str)->slug($table);
             })

--- a/tests/Integration/CachedBuilder/JoinCacheInvalidationTest.php
+++ b/tests/Integration/CachedBuilder/JoinCacheInvalidationTest.php
@@ -167,4 +167,42 @@ class JoinCacheInvalidationTest extends IntegrationTestCase
             'BelongsToMany query should return fresh data after its pivot table is written',
         );
     }
+
+    public function testJoinSubQueryCacheTagsAreBuiltWithoutCrashing()
+    {
+        $subQuery = DB::table('books')
+            ->select('author_id')
+            ->groupBy('author_id');
+
+        $query = (new Author)
+            ->select('authors.*')
+            ->joinSub($subQuery, 'authored', 'authored.author_id', '=', 'authors.id');
+
+        $tags = (new CacheTags(
+            $query->getEagerLoads(),
+            $query->getModel(),
+            $query
+        ))->make();
+
+        $this->assertTrue(
+            collect($tags)->contains(function ($tag) {
+                return str_contains($tag, (new Str)->slug(Author::class));
+            }),
+            'Tags should include the primary model class tag'
+        );
+    }
+
+    public function testJoinSubQueryResultsAreCached()
+    {
+        $subQuery = DB::table('books')
+            ->select('author_id')
+            ->groupBy('author_id');
+
+        $authors = (new Author)
+            ->select('authors.*')
+            ->joinSub($subQuery, 'authored', 'authored.author_id', '=', 'authors.id')
+            ->get();
+
+        $this->assertGreaterThan(0, $authors->count());
+    }
 }


### PR DESCRIPTION
## The bug

`CacheTags::getJoinTags()` assumes every `$join->table` is a string:

```php
if (stripos($table, ' as ') !== false) {
```

`joinSub()` stores an `Illuminate\Database\Query\Expression` there, so the query fails outright as soon as its tags are made:

```
TypeError: stripos(): Argument #1 ($haystack) must be of type string,
Illuminate\Database\Query\Expression given
```

Eloquent's `ofMany()` family builds exactly this kind of join, so the crash is not limited to hand-written `joinSub()` calls — it also hits a `latestOfMany()` relation whose `beforeQuery` callbacks were already materialized by the time tags are built.

## The fix

An expression join has no table name to tag, and its subquery selects from the related model's own table, which is already tagged through that model — so skipping it loses no invalidation. Non-string tables are filtered out before the alias-stripping.

## Tests

Both new tests in `JoinCacheInvalidationTest` error with the `TypeError` above on master and pass with the fix:

- `testJoinSubQueryCacheTagsAreBuiltWithoutCrashing` — tags are produced, and still carry the primary model tag.
- `testJoinSubQueryResultsAreCached` — the end-to-end `get()` on a `joinSub()` query.
