### PR TITLE
fix: keep the where-clause boolean in the cache key

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -326,7 +326,18 @@ class CacheKey
         $column .= isset($where["column"]) ? $where["column"] : "";
         $column .= isset($where["columns"]) ? implode("-", $where["columns"]) : "";
 
-        return "-{$column}_{$value}";
+        // `whereNot("id", 1)` is a Basic clause with the boolean "and not",
+        // identical to `where("id", 1)` in every other respect — so without
+        // the boolean both collapse to `-id_=_1` and an "exclude" query reads
+        // the cached "only" result (and vice versa). The same holds for `or`.
+        // Only non-default booleans are emitted, so existing keys for plain
+        // `where()` clauses are unchanged.
+        $boolean = data_get($where, "boolean", "and");
+        $booleanSlug = $boolean === "and"
+            ? ""
+            : "-" . str_replace(" ", "_", $boolean);
+
+        return "{$booleanSlug}-{$column}_{$value}";
     }
 
     protected function getQueryColumns(array $columns) : string

--- a/tests/Integration/CachedBuilder/WhereNotTest.php
+++ b/tests/Integration/CachedBuilder/WhereNotTest.php
@@ -1,0 +1,60 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedAuthor;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use ReflectionMethod;
+
+class WhereNotTest extends IntegrationTestCase
+{
+    public function testWhereNotProducesDifferentCacheKeyThanWhere()
+    {
+        $query1 = (new Author)
+            ->where('id', 1);
+
+        $query2 = (new Author)
+            ->whereNot('id', 1);
+
+        $cacheKey1 = (new ReflectionMethod($query1, 'makeCacheKey'))
+            ->invoke($query1);
+        $cacheKey2 = (new ReflectionMethod($query2, 'makeCacheKey'))
+            ->invoke($query2);
+
+        $this->assertNotEquals($cacheKey1, $cacheKey2);
+    }
+
+    public function testWhereNotReturnsItsOwnResultsAfterWhereWasCached()
+    {
+        (new Author)
+            ->where('id', 1)
+            ->get();
+
+        $results = (new Author)
+            ->whereNot('id', 1)
+            ->get();
+        $liveResults = (new UncachedAuthor)
+            ->whereNot('id', 1)
+            ->get();
+
+        $this->assertEquals($liveResults->pluck('id'), $results->pluck('id'));
+        $this->assertNotContains(1, $results->pluck('id')->toArray());
+    }
+
+    public function testOrWhereProducesDifferentCacheKeyThanWhere()
+    {
+        $query1 = (new Author)
+            ->where('id', 1)
+            ->where('id', 2);
+
+        $query2 = (new Author)
+            ->where('id', 1)
+            ->orWhere('id', 2);
+
+        $cacheKey1 = (new ReflectionMethod($query1, 'makeCacheKey'))
+            ->invoke($query1);
+        $cacheKey2 = (new ReflectionMethod($query2, 'makeCacheKey'))
+            ->invoke($query2);
+
+        $this->assertNotEquals($cacheKey1, $cacheKey2);
+    }
+}

--- a/tests/Integration/CachedBuilder/WhereTest.php
+++ b/tests/Integration/CachedBuilder/WhereTest.php
@@ -119,7 +119,7 @@ class WhereTest extends IntegrationTestCase
 
     public function testWhereUsesCorrectBinding()
     {
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-nested-name_like_B%-name_like_G%-authors.deleted_at_null");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-nested-name_like_B%-or-name_like_G%-authors.deleted_at_null");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",


### PR DESCRIPTION
## The bug

`getOtherClauses()` builds its fragment from column, operator and value only:

```php
return "-{$column}_{$value}";
```

`whereNot("id", 1)` is a Basic clause whose boolean is `"and not"` and which is identical to `where("id", 1)` in every other respect, so both produce `-id_=_1`. The two queries share a cache entry, and an "exclude X" request reads the cached "only X" result — or the reverse, depending on which ran first. `orWhere()` collides with `where()` the same way.

`getColumnClauses()` and `getInAndNotInClauses()` already include `$where["boolean"]`; this brings Basic clauses in line with them.

## Key stability

Only non-default booleans are emitted:

```php
$boolean === "and" ? "" : "-" . str_replace(" ", "_", $boolean)
```

So every existing key for a plain `where()` clause is byte-identical to before, and caches do not go cold on upgrade. Only keys that were already wrong — the `or` / `not` ones — change.

## Tests

New `WhereNotTest`:

- `testWhereNotProducesDifferentCacheKeyThanWhere` — fails on master with the two keys asserted equal, character for character.
- `testWhereNotReturnsItsOwnResultsAfterWhereWasCached` — the user-visible symptom: `where("id", 1)` is cached first, then `whereNot("id", 1)` must not read it back.
- `testOrWhereProducesDifferentCacheKeyThanWhere` — same collision through `orWhere()`.

One existing expectation is updated: `WhereTest::testWhereUsesCorrectBinding` keys an `orWhere()`, which now carries its `-or`. That was the only hard-coded key in the suite this change touches.

Full suite on this branch: 411 tests, 2 errors — both in `WhereJsonContainsTest`, and both also error on unmodified master in my environment (sqlite/JSON on Windows), so unrelated to this change.
