### PR TITLE
fix: distinguish where-clauses and subquery joins in cache keys and tags

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -19,6 +19,28 @@ class CacheKey
 {
     use CachePrefixing;
 
+    // The key format joins its segments with "-" and "_", so a value holding
+    // either character is ambiguous: where("title", "a-title_=_b") builds the
+    // same key as where("title", "a")->where("title", "b"). Percent-encoding
+    // the separators removes that ambiguity. "%" is encoded as well, because an
+    // encoding whose escape character is itself unescaped is not reversible:
+    // without it the value "a%2Db" and the value "a-b" both come out as
+    // "a%2Db". strtr() rewrites only the characters it finds, so a value
+    // carrying none of the three keeps its exact previous bytes.
+    //
+    // strtr() with an array scans the subject once and never re-reads what it
+    // wrote, so it cannot encode its own output and the order of the pairs
+    // below does not matter to it. It matters to any reimplementation that
+    // replaces sequentially: a str_replace() loop that reaches "%" last encodes
+    // the "%" of the "%2D" it just wrote and turns "-" into "%252D".
+    // WhereValueEscapingTest::testSeparatorEncodingIsNotDoubleEncoded pins the
+    // output, because nothing else here would fail if this were rewritten.
+    private const KEY_SEPARATOR_ESCAPES = [
+        "%" => "%25",
+        "-" => "%2D",
+        "_" => "%5F",
+    ];
+
     protected $currentBinding = 0;
     protected $eagerLoad;
     protected $macroKey;
@@ -143,7 +165,23 @@ class CacheKey
 	    $where["second"] = $this->expressionToString($where["second"]);
         }
 
-        return "-{$where["boolean"]}_{$where["first"]}_{$where["operator"]}_{$where["second"]}";
+        return $this->getBooleanSlug($where)
+            . "-{$where["first"]}_{$where["operator"]}_{$where["second"]}";
+    }
+
+    // Every clause family emits its boolean the same way: nothing for the
+    // default "and", and a "-{boolean}" prefix otherwise. Without it,
+    // whereNot("id", 1) (boolean "and not") and orWhere("id", 1) collapse onto
+    // the same key as where("id", 1), so an "exclude" query reads the cached
+    // "only" result. Omitting the default keeps every plain where() key
+    // byte-identical to the keys this package built before.
+    protected function getBooleanSlug(array $where) : string
+    {
+        $boolean = data_get($where, "boolean", "and");
+
+        return $boolean === "and"
+            ? ""
+            : "-" . str_replace(" ", "_", $boolean);
     }
 
     protected function getCurrentBinding(string $type, $bindingFallback = null)
@@ -184,6 +222,7 @@ class CacheKey
         }
 
         $type = strtolower($where["type"]);
+        $booleanSlug = $this->getBooleanSlug($where);
         $subquery = $this->getValuesFromWhere($where);
 
         if (
@@ -195,12 +234,22 @@ class CacheKey
                 $subquery = Uuid::fromBytes($subquery);
                 $values = $this->recursiveImplode([$subquery], "_");
 
-                return "-{$where["column"]}_{$type}{$values}";
+                return "{$booleanSlug}-{$where["column"]}_{$type}{$values}";
             } catch (Throwable) {
                 // do nothing
             }
         }
 
+        // Escaping starts here, below the branch above, on purpose: that branch
+        // recognises a raw binary UUID by being exactly 16 bytes long, and
+        // encoding a 0x2D or 0x5F byte inside one would stretch it past 16 and
+        // send the value down the wrong path. Everything from here on renders
+        // values straight into the key, so from here on they are escaped —
+        // whereIn("id", ["1_2"]) and whereIn("id", [1, 2]) no longer collide.
+        // The escaping is redone from the individual values rather than applied
+        // to the string above, which is already joined on "_" and would lose
+        // the join itself.
+        $subquery = $this->getValuesFromWhere($where, escape: true);
         $placeholderCount = preg_match_all('/\?(?=(?:[^"]*"[^"]*")*[^"]*\Z)/m', $subquery);
 
         if ($placeholderCount === 0) {
@@ -210,12 +259,19 @@ class CacheKey
 
             $values = $this->recursiveImplode([$subquery], "_");
 
-            return "-{$where["column"]}_{$type}{$values}";
+            return "{$booleanSlug}-{$where["column"]}_{$type}{$values}";
         }
 
+        // The bindings substituted in below land in the key verbatim, so they
+        // are escaped for the same reason the values above are. vsprintf()
+        // reads "%" only in its format string, never in the arguments, so an
+        // encoded value passes through it untouched.
         $values = collect(data_get($this->query->bindings, "where"))
             ->slice($this->currentBinding, $placeholderCount)
-            ->values();
+            ->values()
+            ->map(function ($binding) {
+                return $this->stringifyBinding($binding);
+            });
         $this->currentBinding += $placeholderCount;
 
         $subquery = preg_replace('/\?(?=(?:[^"]*"[^"]*")*[^"]*\Z)/m', "_??_", $subquery);
@@ -223,7 +279,7 @@ class CacheKey
         $subquery = collect(vsprintf(str_replace("_??_", "%s", $subquery), $values->toArray()));
         $values = $this->recursiveImplode($subquery->toArray(), "_");
 
-        return "-{$where["column"]}_{$type}{$values}";
+        return "{$booleanSlug}-{$where["column"]}_{$type}{$values}";
     }
 
     protected function getLimitClause() : string
@@ -248,7 +304,10 @@ class CacheKey
             return "";
         }
 
-        return "-" . strtolower($where["type"]) . $this->getWhereClauses($where["query"]->wheres);
+        return $this->getBooleanSlug($where)
+            . "-"
+            . strtolower($where["type"])
+            . $this->getWhereClauses($where["query"]->wheres);
     }
 
     protected function getOffsetClause() : string
@@ -297,7 +356,7 @@ class CacheKey
         $columns = implode("_", $where["columns"]);
         $operator = str_replace(" ", "_", $where["operator"]);
         $values = implode("_", array_map(function ($value) {
-            return $this->processEnum($value);
+            return $this->escapeKeySegment($this->processEnum($value));
         }, $where["values"]));
 
         // Advance binding pointer for each value in the RowValues clause
@@ -305,7 +364,8 @@ class CacheKey
             $this->currentBinding++;
         }
 
-        return "-{$where["boolean"]}_{$columns}_{$operator}_{$values}";
+        return $this->getBooleanSlug($where)
+            . "-{$columns}_{$operator}_{$values}";
     }
 
     protected function getOtherClauses(array $where) : string
@@ -326,18 +386,7 @@ class CacheKey
         $column .= isset($where["column"]) ? $where["column"] : "";
         $column .= isset($where["columns"]) ? implode("-", $where["columns"]) : "";
 
-        // `whereNot("id", 1)` is a Basic clause with the boolean "and not",
-        // identical to `where("id", 1)` in every other respect — so without
-        // the boolean both collapse to `-id_=_1` and an "exclude" query reads
-        // the cached "only" result (and vice versa). The same holds for `or`.
-        // Only non-default booleans are emitted, so existing keys for plain
-        // `where()` clauses are unchanged.
-        $boolean = data_get($where, "boolean", "and");
-        $booleanSlug = $boolean === "and"
-            ? ""
-            : "-" . str_replace(" ", "_", $boolean);
-
-        return "{$booleanSlug}-{$column}_{$value}";
+        return $this->getBooleanSlug($where) . "-{$column}_{$value}";
     }
 
     protected function getQueryColumns(array $columns) : string
@@ -373,22 +422,19 @@ class CacheKey
             return "";
         }
 
-        $queryParts = explode("?", $where["sql"]);
-        $clause = "_{$where["boolean"]}";
+        // Substitute each binding back into the raw SQL in place of its "?",
+        // so the clause reads as the statement that will actually run.
+        $segments = explode("?", $where["sql"]);
+        $clause = array_shift($segments);
 
-        while (count($queryParts) > 1) {
-            $clause .= "_" . array_shift($queryParts);
-            $clause .= $this->getCurrentBinding("where");
+        foreach ($segments as $segment) {
+            $clause .= $this->getCurrentBinding("where") . $segment;
             $this->currentBinding++;
         }
 
-        $lastPart = array_shift($queryParts);
-
-        if ($lastPart) {
-            $clause .= "_" . $lastPart;
-        }
-
-        return "-" . str_replace(" ", "_", $clause);
+        return $this->getBooleanSlug($where)
+            . "-"
+            . str_replace(" ", "_", $clause);
     }
 
     protected function getTableSlug() : string
@@ -397,13 +443,51 @@ class CacheKey
             . ":";
     }
 
+    // A clause names itself by its type, and adds its comparison operator when
+    // it carries one. The single exception is "Basic" — the plain
+    // where("column", "=", $value) shape — which names itself by its operator
+    // alone. That exception is what keeps every existing plain-where key
+    // byte-identical; everything else needs its type, because a type is the
+    // only thing telling two clauses apart when column, operator and value all
+    // match. whereDate() and where() both compile to "= ?" against the same
+    // column, as do whereDay(5) and whereMonth(5), whose bindings are both the
+    // zero-padded "05".
+    //
+    // This replaces a hard-coded list of type names. That list is what made the
+    // key wrong twice over: it did not name Date, Day, Month, Year, Time, Sub,
+    // JsonLength or JsonBoolean, so each fell through to its operator and lost
+    // its identity; and it did not name betweenColumns, valueBetween, Like or
+    // JsonOverlaps, which carry no operator at all, so each read a key that is
+    // not there and raised "Undefined array key". Stating the rule instead of
+    // enumerating its members is what stops the next type Laravel adds from
+    // landing in one of those two holes.
     protected function getTypeClause($where) : string
     {
-        $type = in_array($where["type"], ["InRaw", "In", "NotIn", "Null", "NotNull", "between", "NotInSub", "InSub", "JsonContains", "Fulltext", "JsonContainsKey"])
-            ? strtolower($where["type"])
-            : strtolower($where["operator"]);
+        $segments = $where["type"] === "Basic"
+            ? []
+            : [strtolower($where["type"])];
 
-        return str_replace(" ", "_", $type);
+        if (data_get($where, "operator") !== null) {
+            $segments[] = strtolower($where["operator"]);
+        }
+
+        // A "Basic" clause always carries an operator, so this is only reached
+        // if something outside Laravel pushes a where array that does not.
+        // Naming it by its type is worse than nothing but better than an empty
+        // segment, which would collapse it onto every other such clause.
+        if ($segments === []) {
+            $segments[] = strtolower($where["type"]);
+        }
+
+        // whereNotBetween(), whereJsonDoesntContain() and their siblings reuse
+        // the affirmative clause's type and negate it with a separate "not"
+        // flag, so without this they share a cache key with the query that
+        // returns exactly the rows they exclude.
+        if (data_get($where, "not", false)) {
+            array_unshift($segments, "not");
+        }
+
+        return str_replace(" ", "_", implode("_", $segments));
     }
 
     protected function getValuesClause(array $where = []) : string
@@ -420,7 +504,11 @@ class CacheKey
         return "_" . $values;
     }
 
-    protected function getValuesFromWhere(array $where) : string
+    // $escape encodes each value individually, before they are joined on "_".
+    // It is off by default because most callers hand the result straight to
+    // getValuesFromBindings(), which discards it and escapes the binding
+    // instead; getInAndNotInClauses() is the caller that keeps it.
+    protected function getValuesFromWhere(array $where, bool $escape = false) : string
     {
         if (array_key_exists("value", $where)
             && is_object($where["value"])
@@ -431,17 +519,17 @@ class CacheKey
 
         if (is_array((new Arr)->get($where, "values"))) {
             $values = collect($where["values"])->flatten()->toArray();
-            return implode("_", $this->processEnums($values));
+            return implode("_", $this->processEnums($values, $escape));
         }
 
         if (is_array((new Arr)->get($where, "value"))) {
             $values = collect($where["value"])->flatten()->toArray();
-            return implode("_", $this->processEnums($values));
+            return implode("_", $this->processEnums($values, $escape));
         }
 
         $value = (new Arr)->get($where, "value", "");
 
-        return $this->processEnum($value);
+        return implode("_", $this->processEnums([$value], $escape));
     }
 
     protected function getValuesFromBindings(array $where, string $values) : string
@@ -449,23 +537,19 @@ class CacheKey
         $bindingFallback = __CLASS__ . ':UNKNOWN_BINDING';
         $currentBinding = $this->getCurrentBinding("where", $bindingFallback);
 
-        if ($currentBinding !== $bindingFallback) {
-            $values = $currentBinding;
+        if ($currentBinding === $bindingFallback) {
+            return $values;
+        }
+
+        $this->currentBinding++;
+        $values = $this->stringifyBinding($currentBinding);
+
+        if ($where["type"] === "between") {
+            $values .= "_" . $this->stringifyBinding($this->getCurrentBinding("where"));
             $this->currentBinding++;
-
-            if ($where["type"] === "between") {
-                $values .= "_" . $this->getCurrentBinding("where");
-                $this->currentBinding++;
-            }
         }
 
-        if (is_object($values)
-            && get_class($values) === "DateTime"
-        ) {
-            $values = $values->format("Y-m-d-H-i-s");
-        }
-
-        return (string) $values;
+        return $values;
     }
 
     protected function getWhereClauses(array $wheres = []) : string
@@ -579,6 +663,26 @@ class CacheKey
         return $result;
     }
 
+    // A bound value is the one key segment an application controls outright, so
+    // it is the one that has to be escaped. Values reached through
+    // getInAndNotInClauses() are deliberately left alone: that path detects a
+    // raw 16-byte binary UUID by its length, which escaping would change.
+    private function stringifyBinding(mixed $binding) : string
+    {
+        if (is_object($binding)
+            && get_class($binding) === "DateTime"
+        ) {
+            $binding = $binding->format("Y-m-d-H-i-s");
+        }
+
+        return $this->escapeKeySegment((string) $binding);
+    }
+
+    private function escapeKeySegment(string $segment) : string
+    {
+        return strtr($segment, self::KEY_SEPARATOR_ESCAPES);
+    }
+
     private function processEnum(
         BackedEnum|UnitEnum|Expression|DateTimeInterface|int|float|bool|string|null $value,
     ): string {
@@ -595,9 +699,14 @@ class CacheKey
         return "{$value}";
     }
 
-    private function processEnums(array $values): array
+    private function processEnums(array $values, bool $escape = false): array
     {
-        return array_map(fn($value) => $this->processEnum($value), $values);
+        return array_map(
+            fn($value) => $escape
+                ? $this->escapeKeySegment($this->processEnum($value))
+                : $this->processEnum($value),
+            $values,
+        );
     }
 
     private function expressionToString(Expression|string $value): string

--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -5,6 +5,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
+use Throwable;
 
 class CacheTags
 {
@@ -66,27 +67,20 @@ class CacheTags
             $baseQuery = $this->query->getQuery();
         }
 
-        $joins = $baseQuery->joins ?? [];
-
-        if (empty($joins)) {
-            return [];
-        }
-
         $prefix = $this->getCachePrefix();
 
-        return collect($joins)
+        return collect($baseQuery->joins ?? [])
             ->map(function ($join) {
                 $table = $join->table;
 
                 // `joinSub()` — and anything else joining a raw expression —
-                // stores an Expression here instead of a table name. There is
-                // no table to tag, and the stripos() below raises a TypeError
-                // on it. Eloquent's `ofMany()` relations build exactly such a
-                // join, so any query whose joins are already materialized when
-                // the tags are made (an explicit `joinSub()`, or an `ofMany()`
-                // query compiled earlier) fails there. The subquery selects
-                // from the related model's own table, which is already tagged
-                // through that model, so skipping it loses no invalidation.
+                // stores an Expression here instead of a table name, and the
+                // stripos() below raises a TypeError on it. Eloquent's
+                // `ofMany()` relations build exactly such a join, so any query
+                // whose joins are already materialized when the tags are made
+                // fails there. The table behind the expression is recovered
+                // from the builder below, which recorded it before Laravel
+                // compiled the subquery.
                 if (! is_string($table)) {
                     return null;
                 }
@@ -98,13 +92,64 @@ class CacheTags
 
                 return $table;
             })
-            ->filter()
+            ->merge($this->getJoinedSubqueryTables($baseQuery))
+            ->filter(function ($table) {
+                return $table !== null;
+            })
             ->map(function ($table) use ($prefix) {
                 return $prefix . (new Str)->slug($table);
             })
             ->unique()
             ->values()
             ->toArray();
+    }
+
+    protected function getJoinedSubqueryTables(mixed $baseQuery) : array
+    {
+        if (! method_exists($baseQuery, "getJoinedSubqueryTables")) {
+            return [];
+        }
+
+        return array_merge(
+            $baseQuery->getJoinedSubqueryTables(),
+            $this->getDeferredJoinedSubqueryTables($baseQuery),
+        );
+    }
+
+    /**
+     * Tables joined by a subquery that has not been built yet.
+     *
+     * Eloquent defers some of its own subquery joins into a beforeQuery()
+     * callback — `ofMany()` is the one in Laravel — and tags are made before
+     * the query runs, so those callbacks have not fired and there is nothing
+     * recorded yet. Running them on a clone materializes the joins, and the
+     * tables they read, without touching the query that will actually execute.
+     *
+     * The callbacks are shared by reference with the original query, so they
+     * run once here and again at execution. That is the same trade CacheKey
+     * already makes to build a key for an `ofMany()` query: harmless for
+     * Eloquent's idempotent, self-clearing family, observable to a custom
+     * non-idempotent callback. A callback that throws yields no tables rather
+     * than breaking tag generation, which leaves the pre-existing gap in place
+     * instead of failing the query outright.
+     */
+    protected function getDeferredJoinedSubqueryTables(mixed $baseQuery) : array
+    {
+        if (
+            ! property_exists($baseQuery, "beforeQueryCallbacks")
+            || ! $baseQuery->beforeQueryCallbacks
+        ) {
+            return [];
+        }
+
+        try {
+            $query = clone $baseQuery;
+            $query->applyBeforeQueryCallbacks();
+
+            return $query->getJoinedSubqueryTables();
+        } catch (Throwable) {
+            return [];
+        }
     }
 
     protected function getRelatedModel($carry) : Model

--- a/src/CachedQueryBuilder.php
+++ b/src/CachedQueryBuilder.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GeneaLabs\LaravelModelCaching;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder;
+
+/**
+ * The base query builder for cachable models, which exists to record the table
+ * a subquery join reads from.
+ *
+ * joinSub() compiles its subquery to SQL and hands join() an
+ * Illuminate\Database\Query\Expression, so the JoinClause names no table and
+ * CacheTags has nothing to tag: a write to that table does not invalidate the
+ * cached query, and the next read is served stale. The name is still
+ * addressable here, one call before createSub() destroys it.
+ *
+ * This has to sit at the query-builder layer rather than on CachedBuilder,
+ * because Eloquent defers some of its own subquery joins into a beforeQuery()
+ * callback — ofMany() is the one in Laravel — and that callback is invoked with
+ * the query builder, never with the Eloquent builder wrapping it.
+ */
+class CachedQueryBuilder extends Builder
+{
+    /** @var array<int, string> */
+    protected array $joinedSubqueryTables = [];
+
+    /**
+     * Tables read by a subquery join, in the order they were joined.
+     */
+    public function getJoinedSubqueryTables(): array
+    {
+        return $this->joinedSubqueryTables;
+    }
+
+    public function joinSub(
+        $query,
+        $as,
+        $first,
+        $operator = null,
+        $second = null,
+        $type = "inner",
+        $where = false,
+    ) {
+        return parent::joinSub(
+            $this->recordJoinedSubqueryTable($query),
+            $as,
+            $first,
+            $operator,
+            $second,
+            $type,
+            $where,
+        );
+    }
+
+    public function leftJoinSub($query, $as, $first, $operator = null, $second = null)
+    {
+        return $this->joinSub($query, $as, $first, $operator, $second, "left");
+    }
+
+    public function rightJoinSub($query, $as, $first, $operator = null, $second = null)
+    {
+        return $this->joinSub($query, $as, $first, $operator, $second, "right");
+    }
+
+    public function joinLateral($query, string $as, string $type = "inner")
+    {
+        return parent::joinLateral($this->recordJoinedSubqueryTable($query), $as, $type);
+    }
+
+    public function leftJoinLateral($query, string $as)
+    {
+        return $this->joinLateral($query, $as, "left");
+    }
+
+    /**
+     * Record the table a subquery join reads from, and return the subquery to
+     * hand on to Laravel unchanged.
+     *
+     * A Closure subquery is wrapped rather than resolved, so the caller's
+     * callback still runs exactly once, inside Laravel's own createSub().
+     */
+    protected function recordJoinedSubqueryTable($query)
+    {
+        if ($query instanceof Closure) {
+            return function ($subQuery) use ($query): void {
+                $query($subQuery);
+                $this->recordJoinedSubqueryTable($subQuery);
+            };
+        }
+
+        $subQuery = $query instanceof Relation
+            ? $query->getQuery()
+            : $query;
+        $subQuery = $subQuery instanceof EloquentBuilder
+            ? $subQuery->getQuery()
+            : $subQuery;
+
+        // `from` is itself an Expression when the subquery selects from another
+        // subquery, and a string subquery is raw SQL rather than a table name.
+        if (
+            $subQuery instanceof Builder
+            && is_string($subQuery->from)
+        ) {
+            $this->joinedSubqueryTables[] = $subQuery->from;
+        }
+
+        return $query;
+    }
+}

--- a/src/Traits/CachesOneOrManyThrough.php
+++ b/src/Traits/CachesOneOrManyThrough.php
@@ -61,7 +61,14 @@ trait CachesOneOrManyThrough
         return $this->cachedValue(func_get_args(), $cacheKey);
     }
 
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null, $total = null)
+    /**
+     * There is deliberately no $total parameter here, unlike Buildable's
+     * paginate(). The relations this trait serves — CachedHasManyThrough and
+     * CachedHasOneThrough — inherit HasOneOrManyThrough::paginate(), which
+     * declares four parameters and runs its own count. A total accepted here
+     * could only be dropped on the floor.
+     */
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
         if (! $this->isCachable()) {
             return parent::paginate($perPage, $columns, $pageName, $page);

--- a/src/Traits/ModelCaching.php
+++ b/src/Traits/ModelCaching.php
@@ -9,10 +9,12 @@ use GeneaLabs\LaravelModelCaching\CachedBuilder;
 use GeneaLabs\LaravelModelCaching\CachedHasManyThrough;
 use GeneaLabs\LaravelModelCaching\CachedHasOneThrough;
 use GeneaLabs\LaravelModelCaching\CachedMorphToMany;
+use GeneaLabs\LaravelModelCaching\CachedQueryBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Carbon;
 
 // phpcs:ignore SlevomatCodingStandard.Classes.ClassLength.ClassTooLong
@@ -35,6 +37,32 @@ trait ModelCaching
         } finally {
             unset($building[$objectId]);
         }
+    }
+
+    /**
+     * Swap in the base query builder that records the table a subquery join
+     * reads from, so CacheTags can tag it after joinSub() has compiled the
+     * subquery to an Expression.
+     *
+     * A model — or anything this trait is mixed into — that already supplies
+     * its own base query builder keeps it. Recording one more table to tag is
+     * worth far less than silently replacing a builder someone else depends on,
+     * so the swap only happens when the builder is Laravel's own.
+     */
+    // phpcs:ignore SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint
+    protected function newBaseQueryBuilder()
+    {
+        $builder = parent::newBaseQueryBuilder();
+
+        if ($builder::class !== QueryBuilder::class) {
+            return $builder;
+        }
+
+        return new CachedQueryBuilder(
+            $builder->getConnection(),
+            $builder->getGrammar(),
+            $builder->getProcessor(),
+        );
     }
 
     public function __get($key)

--- a/tests/Fixtures/AuthorBaseQueryBuilder.php
+++ b/tests/Fixtures/AuthorBaseQueryBuilder.php
@@ -1,0 +1,13 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use Illuminate\Database\Query\Builder;
+
+/**
+ * A custom *base* query builder — the Illuminate\Database\Query\Builder layer,
+ * not the Eloquent one the other builder fixtures cover. It exists to prove
+ * that the package leaves a consumer's own base builder alone rather than
+ * replacing it with CachedQueryBuilder.
+ */
+class AuthorBaseQueryBuilder extends Builder
+{
+}

--- a/tests/Fixtures/AuthorWithCustomBaseBuilder.php
+++ b/tests/Fixtures/AuthorWithCustomBaseBuilder.php
@@ -1,0 +1,27 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use GeneaLabs\LaravelModelCaching\Traits\Cachable;
+
+/**
+ * A cachable Author whose base query builder comes from the class the Cachable
+ * trait is mixed in over.
+ *
+ * The intermediate parent matters. A trait method beats a method inherited from
+ * a parent class, so the package's newBaseQueryBuilder() is the one that runs
+ * here — which is exactly the case where it could clobber a consumer's builder
+ * without ever being asked to. (A model declaring newBaseQueryBuilder() in its
+ * own class body is safe by PHP's own precedence rules: the class body beats
+ * the trait, and the package's version never runs at all.)
+ */
+class AuthorWithCustomBaseBuilder extends AuthorWithCustomBaseBuilderParent
+{
+    use Cachable;
+
+    protected $table = 'authors';
+
+    protected $fillable = [
+        'name',
+        'email',
+        'is_famous',
+    ];
+}

--- a/tests/Fixtures/AuthorWithCustomBaseBuilderParent.php
+++ b/tests/Fixtures/AuthorWithCustomBaseBuilderParent.php
@@ -1,0 +1,22 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Supplies a custom base query builder from a class, so that a subclass mixing
+ * in Cachable reaches the package's newBaseQueryBuilder() rather than this one
+ * — a trait method beats a method inherited from a parent class.
+ */
+abstract class AuthorWithCustomBaseBuilderParent extends Model
+{
+    protected function newBaseQueryBuilder()
+    {
+        $connection = $this->getConnection();
+
+        return new AuthorBaseQueryBuilder(
+            $connection,
+            $connection->getQueryGrammar(),
+            $connection->getPostProcessor(),
+        );
+    }
+}

--- a/tests/Integration/CachedBuilder/BooleanTest.php
+++ b/tests/Integration/CachedBuilder/BooleanTest.php
@@ -66,7 +66,7 @@ class BooleanTest extends IntegrationTestCase
 
     public function testBooleanWhereHasRelationWithFalseConditionAndAdditionalParentRawCondition()
     {
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-exists-and_books.author_id_=_authors.id-is_famous_=_-authors.deleted_at_null-_and_title_=_Mixed_Clause");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-exists-books.author_id_=_authors.id-is_famous_=_-authors.deleted_at_null-title_=_Mixed_Clause");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",

--- a/tests/Integration/CachedBuilder/DateTimeTest.php
+++ b/tests/Integration/CachedBuilder/DateTimeTest.php
@@ -11,7 +11,10 @@ class DateTimeTest extends IntegrationTestCase
     public function testWhereClauseWorksWithCarbonDate()
     {
         $dateTime = now()->subYears(10);
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-publish_at_>_{$dateTime}");
+        // The "-" separating the date parts is a key separator, so the value
+        // segment carries it percent-encoded.
+        $encodedDateTime = str_replace("-", "%2D", (string) $dateTime);
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-publish_at_>_{$encodedDateTime}");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
@@ -38,7 +41,7 @@ class DateTimeTest extends IntegrationTestCase
     {
         $dateTime = (new DateTime('@' . time()))
             ->sub(new DateInterval("P10Y"));
-        $dateTimeString = $dateTime->format("Y-m-d-H-i-s");
+        $dateTimeString = str_replace("-", "%2D", $dateTime->format("Y-m-d-H-i-s"));
         $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-publish_at_>_{$dateTimeString}");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",

--- a/tests/Integration/CachedBuilder/JoinCacheInvalidationTest.php
+++ b/tests/Integration/CachedBuilder/JoinCacheInvalidationTest.php
@@ -1,11 +1,15 @@
 <?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
 
+use GeneaLabs\LaravelModelCaching\CachedQueryBuilder;
 use GeneaLabs\LaravelModelCaching\CacheTags;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\AuthorBaseQueryBuilder;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\AuthorWithCustomBaseBuilder;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\CachableRoleUser;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Store;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedAuthor;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\User;
 use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
 use Illuminate\Support\Facades\DB;
@@ -194,15 +198,219 @@ class JoinCacheInvalidationTest extends IntegrationTestCase
 
     public function testJoinSubQueryResultsAreCached()
     {
-        $subQuery = DB::table('books')
-            ->select('author_id')
-            ->groupBy('author_id');
-
-        $authors = (new Author)
+        $query = (new Author)
             ->select('authors.*')
-            ->joinSub($subQuery, 'authored', 'authored.author_id', '=', 'authors.id')
-            ->get();
+            ->joinSub($this->authoredSubQuery(), 'authored', 'authored.author_id', '=', 'authors.id');
+        $key = sha1((new ReflectionMethod($query, 'makeCacheKey'))->invoke($query));
+        $authors = $query->get();
+
+        $cached = $this->cache()
+            ->tags((new ReflectionMethod($query, 'makeCacheTags'))->invoke($query))
+            ->get($key);
 
         $this->assertGreaterThan(0, $authors->count());
+        $this->assertNotNull($cached, 'The joinSub query should have been cached');
+        $this->assertEquals($authors->pluck('id'), $cached['value']->pluck('id'));
+    }
+
+    private function authoredSubQuery()
+    {
+        return DB::table('books')
+            ->select('author_id')
+            ->groupBy('author_id');
+    }
+
+    private function joinSubTags($query) : array
+    {
+        return (new CacheTags(
+            $query->getEagerLoads(),
+            $query->getModel(),
+            $query
+        ))->make();
+    }
+
+    public function testJoinSubQueryCacheTagsContainTheSubqueryTableTag()
+    {
+        $query = (new Author)
+            ->select('authors.*')
+            ->joinSub($this->authoredSubQuery(), 'authored', 'authored.author_id', '=', 'authors.id');
+
+        $this->assertContains(
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+            $this->joinSubTags($query),
+            'joinSub() should tag the table its subquery reads from',
+        );
+    }
+
+    public function testLeftJoinSubQueryCacheTagsContainTheSubqueryTableTag()
+    {
+        $query = (new Author)
+            ->select('authors.*')
+            ->leftJoinSub($this->authoredSubQuery(), 'authored', 'authored.author_id', '=', 'authors.id');
+
+        $this->assertContains(
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+            $this->joinSubTags($query),
+            'leftJoinSub() should tag the table its subquery reads from',
+        );
+    }
+
+    public function testJoinSubQueryCacheTagsContainTheSubqueryTableTagForAClosureSubquery()
+    {
+        $query = (new Author)
+            ->select('authors.*')
+            ->joinSub(
+                function ($subQuery) {
+                    $subQuery->from('books')
+                        ->select('author_id')
+                        ->groupBy('author_id');
+                },
+                'authored',
+                'authored.author_id',
+                '=',
+                'authors.id'
+            );
+
+        $this->assertContains(
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+            $this->joinSubTags($query),
+            'A Closure subquery should be recorded the same way a builder is',
+        );
+    }
+
+    public function testJoinSubQueryCacheIsInvalidatedWhenTheSubqueryTableIsWritten()
+    {
+        // An author with no books is invisible to the inner-joined subquery,
+        // so giving them one changes the row count the query returns.
+        $authorWithoutBooks = Author::factory()->create();
+
+        $before = (new Author)
+            ->select('authors.*')
+            ->joinSub($this->authoredSubQuery(), 'authored', 'authored.author_id', '=', 'authors.id')
+            ->get();
+
+        Book::factory()->create(['author_id' => $authorWithoutBooks->id]);
+
+        $afterCachedRead = (new Author)
+            ->select('authors.*')
+            ->joinSub($this->authoredSubQuery(), 'authored', 'authored.author_id', '=', 'authors.id')
+            ->get();
+        $liveTruth = (new UncachedAuthor)
+            ->select('authors.*')
+            ->joinSub($this->authoredSubQuery(), 'authored', 'authored.author_id', '=', 'authors.id')
+            ->get();
+
+        $this->assertCount($before->count() + 1, $liveTruth);
+        $this->assertEquals(
+            $liveTruth->pluck('id'),
+            $afterCachedRead->pluck('id'),
+            'A write to the subquery table should invalidate the cached joinSub query',
+        );
+    }
+
+    private function withDeferredJoinSub($model)
+    {
+        return $model
+            ->select('authors.*')
+            ->beforeQuery(function ($base) {
+                $base->joinSub(
+                    DB::table('books')
+                        ->select('author_id')
+                        ->groupBy('author_id'),
+                    'authored',
+                    'authored.author_id',
+                    '=',
+                    'authors.id'
+                );
+            });
+    }
+
+    // The case that justifies the base query builder existing at all. Eloquent
+    // defers some of its own subquery joins into a beforeQuery() callback, and
+    // that callback is handed the query builder, never the Eloquent builder
+    // wrapping it — so a hook on CachedBuilder never sees the join. Before this,
+    // the query below tagged only "author" and "authors"; a write to books left
+    // the cached rows in place.
+    public function testDeferredJoinSubQueryCacheTagsContainTheSubqueryTableTag()
+    {
+        $query = $this->withDeferredJoinSub(new Author);
+        $tags = (new ReflectionMethod($query, 'makeCacheTags'))
+            ->invoke($query);
+
+        $this->assertContains(
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+            $tags,
+            'A subquery join added by a beforeQuery callback should tag the table it reads',
+        );
+    }
+
+    public function testDeferredJoinSubQueryCacheIsInvalidatedWhenTheSubqueryTableIsWritten()
+    {
+        // An author with no books is invisible to the inner-joined subquery, so
+        // giving them one changes the row count the query returns.
+        $authorWithoutBooks = Author::factory()->create();
+
+        $before = $this->withDeferredJoinSub(new Author)->get();
+
+        Book::factory()->create(['author_id' => $authorWithoutBooks->id]);
+
+        $afterCachedRead = $this->withDeferredJoinSub(new Author)->get();
+        $liveTruth = $this->withDeferredJoinSub(new UncachedAuthor)->get();
+
+        $this->assertCount($before->count() + 1, $liveTruth);
+        $this->assertEquals(
+            $liveTruth->pluck('id'),
+            $afterCachedRead->pluck('id'),
+            'A write to the subquery table should invalidate the deferred joinSub query',
+        );
+    }
+
+    // A tag is worth nothing if the builder it came from replaced one the
+    // consumer supplied. The package only swaps in its own base query builder
+    // when the model is using Laravel's.
+    public function testACustomBaseQueryBuilderIsNotReplaced()
+    {
+        $builder = (new ReflectionMethod(new AuthorWithCustomBaseBuilder, 'newBaseQueryBuilder'))
+            ->invoke(new AuthorWithCustomBaseBuilder);
+
+        $this->assertInstanceOf(AuthorBaseQueryBuilder::class, $builder);
+        $this->assertNotInstanceOf(CachedQueryBuilder::class, $builder);
+    }
+
+    public function testTheDefaultBaseQueryBuilderIsTheRecordingOne()
+    {
+        $builder = (new ReflectionMethod(new Author, 'newBaseQueryBuilder'))
+            ->invoke(new Author);
+
+        $this->assertInstanceOf(CachedQueryBuilder::class, $builder);
+    }
+
+    // Not an ofMany() test on purpose. An ofMany() relation already tags the
+    // related model's own table through that model, so its tags are identical
+    // with and without any recording — a test for it would pass before the fix
+    // as readily as after. The deferred joinSub above is the case that changes.
+    public function testOfManyRelationBuildsCacheTagsWithoutRaisingATypeError()
+    {
+        $author = (new Author)->first();
+        $relation = $author->newestBook();
+
+        // Executing the relation first runs the deferred beforeQuery callback
+        // that builds the ofMany() join, so the JoinClause holds a compiled
+        // Expression by the time the tags are made — the shape that used to
+        // raise a TypeError inside stripos().
+        $relation->first();
+
+        $builder = $relation->getQuery();
+        $tags = (new ReflectionMethod($builder, 'makeCacheTags'))
+            ->invoke($builder);
+
+        // The ofMany() subquery reads from the related model's own table, so
+        // that table is already tagged through the model; unlike a hand-written
+        // joinSub() against an unrelated table, nothing has to be recovered
+        // from the compiled expression here.
+        $this->assertContains(
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+            $tags,
+        );
     }
 }

--- a/tests/Integration/CachedBuilder/OrWhereTest.php
+++ b/tests/Integration/CachedBuilder/OrWhereTest.php
@@ -1,0 +1,272 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use ReflectionMethod;
+
+// An "or" clause widens a result set; its "and" twin narrows it. They used to
+// share a cache key in every clause family except Basic, so the cheaper query
+// answered for the stricter one.
+//
+// Book carries no global scope on purpose. Author uses SoftDeletes, and
+// Eloquent's addNewWheresWithinGroup() wraps the pre-existing clauses in a
+// nested group the moment an "or" appears, which moves the key on its own — a
+// test written against Author cannot tell that apart from the boolean landing
+// in the key.
+class OrWhereTest extends IntegrationTestCase
+{
+    private function cacheKey($query) : string
+    {
+        return (new ReflectionMethod($query, "makeCacheKey"))
+            ->invoke($query);
+    }
+
+    private function keyPrefix() : string
+    {
+        return "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite"
+            . ":books:genealabslaravelmodelcachingtestsfixturesbook";
+    }
+
+    private function bookTags() : array
+    {
+        return [
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+        ];
+    }
+
+    private function assertFirstQueryWasCached($query, string $description) : void
+    {
+        $key = sha1($this->cacheKey($query));
+        $results = $query->get();
+        $cached = $this->cache()
+            ->tags($this->bookTags())
+            ->get($key);
+
+        $this->assertNotNull(
+            $cached,
+            "{$description} must populate the cache, or the second query has nothing to collide with"
+        );
+        $this->assertEquals($results->pluck("id"), $cached["value"]->pluck("id"));
+    }
+
+    public function testOrWhereProducesDifferentCacheKeyThanWhere()
+    {
+        $and = (new Book)->where("id", 1)->where("id", 2);
+        $or = (new Book)->where("id", 1)->orWhere("id", 2);
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-id_=_2",
+            $this->cacheKey($and)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-or-id_=_2",
+            $this->cacheKey($or)
+        );
+    }
+
+    public function testOrWhereReturnsItsOwnResultsAfterWhereWasCached()
+    {
+        $this->assertFirstQueryWasCached(
+            (new Book)->where("id", 1)->where("id", 2),
+            "The and-query"
+        );
+
+        $results = (new Book)->where("id", 1)->orWhere("id", 2)->get();
+        $liveResults = (new UncachedBook)->where("id", 1)->orWhere("id", 2)->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+        $this->assertCount(2, $results);
+    }
+
+    public function testOrWhereClosureProducesDifferentCacheKeyThanWhereClosure()
+    {
+        $and = (new Book)
+            ->where("id", 1)
+            ->where(function ($query) {
+                $query->where("id", 2);
+            });
+        $or = (new Book)
+            ->where("id", 1)
+            ->orWhere(function ($query) {
+                $query->where("id", 2);
+            });
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-nested-id_=_2",
+            $this->cacheKey($and)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-or-nested-id_=_2",
+            $this->cacheKey($or)
+        );
+    }
+
+    public function testOrWhereClosureReturnsItsOwnResultsAfterWhereClosureWasCached()
+    {
+        $this->assertFirstQueryWasCached(
+            (new Book)
+                ->where("id", 1)
+                ->where(function ($query) {
+                    $query->where("id", 2);
+                }),
+            "The and-query"
+        );
+
+        $results = (new Book)
+            ->where("id", 1)
+            ->orWhere(function ($query) {
+                $query->where("id", 2);
+            })
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->where("id", 1)
+            ->orWhere(function ($query) {
+                $query->where("id", 2);
+            })
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+        $this->assertCount(2, $results);
+    }
+
+    public function testOrWhereHasProducesDifferentCacheKeyThanWhereHas()
+    {
+        $and = (new Book)
+            ->where("id", 1)
+            ->whereHas("author", function ($query) {
+                $query->where("id", 2);
+            });
+        $or = (new Book)
+            ->where("id", 1)
+            ->orWhereHas("author", function ($query) {
+                $query->where("id", 2);
+            });
+        $existsClause = "-exists-books.author_id_=_authors.id-id_=_2-authors.deleted_at_null";
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1" . $existsClause,
+            $this->cacheKey($and)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-or" . $existsClause,
+            $this->cacheKey($or)
+        );
+    }
+
+    public function testOrWhereHasReturnsItsOwnResultsAfterWhereHasWasCached()
+    {
+        $this->assertFirstQueryWasCached(
+            (new Book)
+                ->where("id", 1)
+                ->whereHas("author", function ($query) {
+                    $query->where("id", 2);
+                }),
+            "The whereHas-query"
+        );
+
+        $results = (new Book)
+            ->where("id", 1)
+            ->orWhereHas("author", function ($query) {
+                $query->where("id", 2);
+            })
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->where("id", 1)
+            ->orWhereHas("author", function ($query) {
+                $query->where("id", 2);
+            })
+            ->get();
+
+        $this->assertNotEmpty($results);
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+    }
+
+    public function testOrWhereInProducesDifferentCacheKeyThanWhereIn()
+    {
+        $and = (new Book)->where("id", 1)->whereIn("id", [1, 2]);
+        $or = (new Book)->where("id", 1)->orWhereIn("id", [1, 2]);
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-id_in_1_2",
+            $this->cacheKey($and)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-or-id_in_1_2",
+            $this->cacheKey($or)
+        );
+    }
+
+    public function testOrWhereInReturnsItsOwnResultsAfterWhereInWasCached()
+    {
+        $this->assertFirstQueryWasCached(
+            (new Book)->where("id", 1)->whereIn("id", [1, 2]),
+            "The whereIn-query"
+        );
+
+        $results = (new Book)->where("id", 1)->orWhereIn("id", [1, 2])->get();
+        $liveResults = (new UncachedBook)->where("id", 1)->orWhereIn("id", [1, 2])->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+        $this->assertCount(2, $results);
+    }
+
+    public function testOrWhereNotInProducesDifferentCacheKeyThanWhereNotIn()
+    {
+        $and = (new Book)->where("id", 1)->whereNotIn("id", [1, 2]);
+        $or = (new Book)->where("id", 1)->orWhereNotIn("id", [1, 2]);
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-id_notin_1_2",
+            $this->cacheKey($and)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-or-id_notin_1_2",
+            $this->cacheKey($or)
+        );
+    }
+
+    public function testOrWhereNotInReturnsItsOwnResultsAfterWhereNotInWasCached()
+    {
+        $this->assertFirstQueryWasCached(
+            (new Book)->where("id", 1)->whereNotIn("id", [1, 2]),
+            "The whereNotIn-query"
+        );
+
+        $results = (new Book)->where("id", 1)->orWhereNotIn("id", [1, 2])->get();
+        $liveResults = (new UncachedBook)->where("id", 1)->orWhereNotIn("id", [1, 2])->get();
+
+        $this->assertNotEmpty($results);
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+    }
+
+    public function testOrWhereIntegerInRawProducesDifferentCacheKeyThanWhereIntegerInRaw()
+    {
+        $and = (new Book)->where("id", 1)->whereIntegerInRaw("id", [1, 2]);
+        $or = (new Book)->where("id", 1)->orWhereIntegerInRaw("id", [1, 2]);
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-id_inraw_1_2",
+            $this->cacheKey($and)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1-or-id_inraw_1_2",
+            $this->cacheKey($or)
+        );
+    }
+
+    public function testOrWhereIntegerInRawReturnsItsOwnResultsAfterWhereIntegerInRawWasCached()
+    {
+        $this->assertFirstQueryWasCached(
+            (new Book)->where("id", 1)->whereIntegerInRaw("id", [1, 2]),
+            "The whereIntegerInRaw-query"
+        );
+
+        $results = (new Book)->where("id", 1)->orWhereIntegerInRaw("id", [1, 2])->get();
+        $liveResults = (new UncachedBook)->where("id", 1)->orWhereIntegerInRaw("id", [1, 2])->get();
+
+        $this->assertCount(2, $results);
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+    }
+}

--- a/tests/Integration/CachedBuilder/PaginateTest.php
+++ b/tests/Integration/CachedBuilder/PaginateTest.php
@@ -2,8 +2,11 @@
 
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\StoreWithUncachedBooks;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedAuthor;
 use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use Illuminate\Support\Facades\DB;
+use ReflectionMethod;
 
 /**
 * @SuppressWarnings(PHPMD.TooManyPublicMethods)
@@ -190,12 +193,61 @@ class PaginateTest extends IntegrationTestCase
         );
     }
 
+    // disableModelCaching() cannot exercise this: it makes newQuery() return a
+    // plain Eloquent builder, so Buildable::paginate() never runs and the test
+    // measures Laravel's own paginate() instead. A cachable model eager-loading
+    // an uncachable one is the construction that reaches Buildable::paginate()
+    // with isCachable() false.
     public function testUncachedPaginationHonorsProvidedTotal()
     {
-        $authors = (new Author)
-            ->disableModelCaching()
-            ->paginate(3, ["*"], "page", 1, 999);
+        $builder = (new StoreWithUncachedBooks)->with("books");
 
-        $this->assertEquals(999, $authors->total());
+        $this->assertFalse(
+            (new ReflectionMethod($builder, "isCachable"))->invoke($builder),
+            "The builder must be a CachedBuilder that reports itself uncachable"
+        );
+
+        $countQueries = [];
+        DB::listen(function ($query) use (&$countQueries) {
+            if (str_contains(strtolower($query->sql), "count(")) {
+                $countQueries[] = $query->sql;
+            }
+        });
+
+        $stores = $builder->paginate(3, ["*"], "page", 1, 999);
+
+        $this->assertEquals(999, $stores->total());
+        $this->assertEmpty(
+            $countQueries,
+            "Passing a total is how a caller skips the count(*); running one anyway defeats it"
+        );
+    }
+
+    // CachesOneOrManyThrough::paginate() lost its inert $total parameter and now
+    // matches the four-parameter signature HasOneOrManyThrough declares. Author
+    // has the only relation in the fixtures that reaches that trait
+    // (hasManyThrough), so this is what covers the changed method: it still
+    // paginates and still caches.
+    public function testHasManyThroughPaginationIsCached()
+    {
+        $relation = (new Author)
+            ->first()
+            ->printers();
+        $key = sha1(
+            (new ReflectionMethod($relation, "makeCacheKey"))
+                ->invoke($relation, ["*"], null, "-paginate_by_2_page_1")
+        );
+        $printers = $relation->paginate(2, ["*"], "page", 1);
+
+        $cached = $this->cache()
+            ->tags((new ReflectionMethod($relation, "makeCacheTags"))->invoke($relation))
+            ->get($key);
+
+        $this->assertCount(2, $printers);
+        $this->assertNotNull($cached, "The relation pagination should have been cached");
+        $this->assertEquals(
+            $printers->pluck("id"),
+            $cached["value"]->pluck("id")
+        );
     }
 }

--- a/tests/Integration/CachedBuilder/ScopeTest.php
+++ b/tests/Integration/CachedBuilder/ScopeTest.php
@@ -22,7 +22,7 @@ class ScopeTest extends IntegrationTestCase
         $authors = (new Author)
             ->startsWithA()
             ->get();
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-name_like_A%-authors.deleted_at_null");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-name_like_A%25-authors.deleted_at_null");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
@@ -48,7 +48,7 @@ class ScopeTest extends IntegrationTestCase
         $authors = (new Author)
             ->nameStartsWith("B")
             ->get();
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-name_like_B%-authors.deleted_at_null");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-name_like_B%25-authors.deleted_at_null");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
@@ -75,7 +75,7 @@ class ScopeTest extends IntegrationTestCase
             ->first();
         $authors = (new AuthorBeginsWithScoped)
             ->get();
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthorbeginswithscoped-name_like_A%0=A%25");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthorbeginswithscoped-name_like_A%250=A%25");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthorbeginswithscoped",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
@@ -100,7 +100,7 @@ class ScopeTest extends IntegrationTestCase
             ->first();
         $authors = (new AuthorWithInlineGlobalScope)
             ->get();
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthorwithinlineglobalscope-authors.deleted_at_null-name_like_A%0=A%25");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthorwithinlineglobalscope-authors.deleted_at_null-name_like_A%250=A%25");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthorwithinlineglobalscope",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",

--- a/tests/Integration/CachedBuilder/WhereBetweenColumnsTest.php
+++ b/tests/Integration/CachedBuilder/WhereBetweenColumnsTest.php
@@ -1,0 +1,94 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use ReflectionMethod;
+
+// whereBetweenColumns() carries no "operator", so the cache key builder used to
+// read a key that is not there and raise "Undefined array key". Under Laravel's
+// default error handler that converts to an ErrorException, so the query threw
+// instead of returning rows.
+class WhereBetweenColumnsTest extends IntegrationTestCase
+{
+    private function cacheKey($query) : string
+    {
+        return (new ReflectionMethod($query, "makeCacheKey"))
+            ->invoke($query);
+    }
+
+    private function keyPrefix() : string
+    {
+        return "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite"
+            . ":books:genealabslaravelmodelcachingtestsfixturesbook";
+    }
+
+    public function testWhereBetweenColumnsProducesACacheKeyWithoutRaisingAWarning()
+    {
+        $query = (new Book)->whereBetweenColumns("published_at", ["created_at", "updated_at"]);
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-published_at_betweencolumns_created_at_updated_at",
+            $this->cacheKey($query)
+        );
+    }
+
+    public function testWhereNotBetweenColumnsProducesADifferentCacheKey()
+    {
+        $between = (new Book)->whereBetweenColumns("published_at", ["created_at", "updated_at"]);
+        $notBetween = (new Book)->whereNotBetweenColumns("published_at", ["created_at", "updated_at"]);
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-published_at_betweencolumns_created_at_updated_at",
+            $this->cacheKey($between)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-published_at_not_betweencolumns_created_at_updated_at",
+            $this->cacheKey($notBetween)
+        );
+    }
+
+    public function testWhereBetweenColumnsReturnsRowsRatherThanThrowing()
+    {
+        $results = (new Book)
+            ->whereBetweenColumns("published_at", ["created_at", "updated_at"])
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->whereBetweenColumns("published_at", ["created_at", "updated_at"])
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+    }
+
+    public function testWhereNotBetweenColumnsReturnsItsOwnResultsAfterWhereBetweenColumnsWasCached()
+    {
+        $betweenQuery = (new Book)
+            ->whereBetweenColumns("published_at", ["created_at", "updated_at"]);
+        $betweenKey = sha1($this->cacheKey($betweenQuery));
+        $betweenResults = $betweenQuery->get();
+        $tags = [
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+        ];
+
+        $cached = $this->cache()
+            ->tags($tags)
+            ->get($betweenKey);
+
+        $this->assertNotNull(
+            $cached,
+            "The first query must populate the cache, or the second query has nothing to collide with"
+        );
+        $this->assertEquals($betweenResults->pluck("id"), $cached["value"]->pluck("id"));
+
+        $results = (new Book)
+            ->whereNotBetweenColumns("published_at", ["created_at", "updated_at"])
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->whereNotBetweenColumns("published_at", ["created_at", "updated_at"])
+            ->get();
+
+        $this->assertNotEmpty($results);
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+    }
+}

--- a/tests/Integration/CachedBuilder/WhereDateFamilyTest.php
+++ b/tests/Integration/CachedBuilder/WhereDateFamilyTest.php
@@ -1,0 +1,225 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use ReflectionMethod;
+
+// whereDate(), whereDay(), whereMonth(), whereYear() and whereTime() all compile
+// to "= ?" against the same column, so a key built from the operator alone
+// cannot tell them apart — from each other, or from a plain where(). whereDay(5)
+// and whereMonth(5) are the worst pair: Laravel zero-pads both bindings to "05",
+// so the two keys matched byte for byte while the queries return unrelated rows.
+//
+// Book carries no global scope; Author's SoftDeletes scope adds clauses that
+// would mask which segment of the key actually changed.
+class WhereDateFamilyTest extends IntegrationTestCase
+{
+    private function cacheKey($query) : string
+    {
+        return (new ReflectionMethod($query, "makeCacheKey"))
+            ->invoke($query);
+    }
+
+    private function keyPrefix() : string
+    {
+        return "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite"
+            . ":books:genealabslaravelmodelcachingtestsfixturesbook";
+    }
+
+    private function bookTags() : array
+    {
+        return [
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+        ];
+    }
+
+    private function assertFirstQueryWasCached($query, string $description) : void
+    {
+        $key = sha1($this->cacheKey($query));
+        $results = $query->get();
+        $cached = $this->cache()
+            ->tags($this->bookTags())
+            ->get($key);
+
+        $this->assertNotNull(
+            $cached,
+            "{$description} must populate the cache, or the second query has nothing to collide with"
+        );
+        $this->assertEquals($results->pluck("id"), $cached["value"]->pluck("id"));
+    }
+
+    // This is the constraint the whole change is held to: a plain where() clause
+    // renders by its operator alone, exactly as it always has, so no ordinary
+    // query goes cold on upgrade. It is the only clause type with that
+    // exemption, and this pins it.
+    public function testPlainWhereKeyIsUnchanged()
+    {
+        $this->assertEquals(
+            $this->keyPrefix() . "-published_at_=_2020%2D01%2D05",
+            $this->cacheKey((new Book)->where("published_at", "=", "2020-01-05"))
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_5",
+            $this->cacheKey((new Book)->where("id", "=", 5))
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_like_abc",
+            $this->cacheKey((new Book)->where("title", "like", "abc"))
+        );
+    }
+
+    public function testWhereDateProducesADifferentCacheKeyThanWhere()
+    {
+        $this->assertEquals(
+            $this->keyPrefix() . "-published_at_=_2020%2D01%2D05",
+            $this->cacheKey((new Book)->where("published_at", "=", "2020-01-05"))
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-published_at_date_=_2020%2D01%2D05",
+            $this->cacheKey((new Book)->whereDate("published_at", "=", "2020-01-05"))
+        );
+    }
+
+    public function testWhereDayProducesADifferentCacheKeyThanWhereMonth()
+    {
+        $this->assertEquals(
+            $this->keyPrefix() . "-published_at_day_=_05",
+            $this->cacheKey((new Book)->whereDay("published_at", 5))
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-published_at_month_=_05",
+            $this->cacheKey((new Book)->whereMonth("published_at", 5))
+        );
+    }
+
+    public function testWhereYearWhereTimeAndWhereProduceThreeDifferentCacheKeys()
+    {
+        $keys = [
+            $this->cacheKey((new Book)->where("published_at", "=", 5)),
+            $this->cacheKey((new Book)->whereYear("published_at", 5)),
+            $this->cacheKey((new Book)->whereTime("published_at", "=", 5)),
+        ];
+
+        $this->assertEquals($this->keyPrefix() . "-published_at_=_5", $keys[0]);
+        $this->assertEquals($this->keyPrefix() . "-published_at_year_=_5", $keys[1]);
+        $this->assertEquals($this->keyPrefix() . "-published_at_time_=_5", $keys[2]);
+        $this->assertCount(3, array_unique($keys));
+    }
+
+    public function testWhereDateReturnsItsOwnResultsAfterWhereWasCached()
+    {
+        $book = (new UncachedBook)->first();
+        $book->published_at = "2020-01-05 13:45:00";
+        $book->save();
+
+        $this->assertFirstQueryWasCached(
+            (new Book)->where("published_at", "=", "2020-01-05"),
+            "The plain where-query"
+        );
+
+        $results = (new Book)
+            ->whereDate("published_at", "=", "2020-01-05")
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->whereDate("published_at", "=", "2020-01-05")
+            ->get();
+
+        // The plain where() matches nothing — "2020-01-05" is not the stored
+        // datetime — while whereDate() matches the row. Sharing a key served the
+        // empty result for both.
+        $this->assertCount(1, $results);
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+    }
+
+    public function testWhereMonthReturnsItsOwnResultsAfterWhereDayWasCached()
+    {
+        $book = (new UncachedBook)->first();
+        $book->published_at = "2020-01-05 13:45:00";
+        $book->save();
+
+        $this->assertFirstQueryWasCached(
+            (new Book)->whereDay("published_at", 5),
+            "The whereDay-query"
+        );
+
+        $results = (new Book)->whereMonth("published_at", 5)->get();
+        $liveResults = (new UncachedBook)->whereMonth("published_at", 5)->get();
+        $dayResults = (new UncachedBook)->whereDay("published_at", 5)->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+        $this->assertNotEquals(
+            $dayResults->pluck("id"),
+            $results->pluck("id"),
+            "The fixture must make the two queries return different rows, or this proves nothing"
+        );
+    }
+
+    // Both queries bind the same value, 2020, which is the whole point: the
+    // binding is the only thing the key used to carry, so the two shared it.
+    // whereYear matches the row and whereTime matches nothing, so serving one
+    // from the other's cache entry is observable.
+    public function testWhereTimeReturnsItsOwnResultsAfterWhereYearWasCached()
+    {
+        $book = (new UncachedBook)->first();
+        $book->published_at = "2020-01-05 13:45:00";
+        $book->save();
+
+        $yearQuery = (new Book)->whereYear("published_at", 2020);
+        $timeQuery = (new Book)->whereTime("published_at", "=", 2020);
+
+        $this->assertNotEquals(
+            $this->cacheKey($yearQuery),
+            $this->cacheKey($timeQuery),
+            "Both bind 2020, so only the clause type can tell these keys apart"
+        );
+
+        $this->assertFirstQueryWasCached($yearQuery, "The whereYear-query");
+
+        $results = $timeQuery->get();
+        $liveResults = (new UncachedBook)
+            ->whereTime("published_at", "=", 2020)
+            ->get();
+        $yearResults = (new UncachedBook)
+            ->whereYear("published_at", 2020)
+            ->get();
+
+        $this->assertNotEmpty(
+            $yearResults,
+            "The fixture must make whereYear match something, or this proves nothing"
+        );
+        $this->assertEmpty($results);
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+    }
+
+    // Not the date family, but the same defect from the same cause: the type
+    // was dropped, so the clause was named by its operator alone and matched a
+    // plain where() on the same column and value.
+    public function testWhereJsonLengthProducesADifferentCacheKeyThanWhere()
+    {
+        $this->assertEquals(
+            $this->keyPrefix() . "-description_>_1",
+            $this->cacheKey((new Book)->where("description", ">", 1))
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-description_jsonlength_>_1",
+            $this->cacheKey((new Book)->whereJsonLength("description", ">", 1))
+        );
+    }
+
+    public function testWhereSubProducesADifferentCacheKeyThanWhere()
+    {
+        $plain = $this->cacheKey((new Book)->where("author_id", "=", 1));
+        $sub = $this->cacheKey(
+            (new Book)->where("author_id", "=", function ($query) {
+                $query->from("authors")
+                    ->selectRaw("1");
+            })
+        );
+
+        $this->assertEquals($this->keyPrefix() . "-author_id_=_1", $plain);
+        $this->assertStringContainsString("-author_id_sub_=_", $sub);
+        $this->assertNotEquals($plain, $sub);
+    }
+}

--- a/tests/Integration/CachedBuilder/WhereHasMorphTest.php
+++ b/tests/Integration/CachedBuilder/WhereHasMorphTest.php
@@ -23,7 +23,7 @@ class WhereHasMorphTest extends IntegrationTestCase
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments",
         ])
             ->get(sha1(
-                "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-nested-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post-exists-and_comments.commentable_id_=_posts.id"
+                "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-nested-or-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post-exists-comments.commentable_id_=_posts.id"
             ))['value'];
 
         $this->assertCount(5, $comments);
@@ -45,7 +45,7 @@ class WhereHasMorphTest extends IntegrationTestCase
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments",
         ])
             ->get(sha1(
-                "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-nested-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post-exists-and_comments.commentable_id_=_posts.id-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedPost-exists-and_comments.commentable_id_=_posts.id"
+                "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-nested-or-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post-exists-comments.commentable_id_=_posts.id-or-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedPost-exists-comments.commentable_id_=_posts.id"
             ))['value'];
 
         $this->assertCount(10, $comments);
@@ -71,7 +71,7 @@ class WhereHasMorphTest extends IntegrationTestCase
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments",
         ])
             ->get(sha1(
-                "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-nested-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post-exists-and_comments.commentable_id_=_posts.id-subject_like_%uncached post-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedPost-exists-and_comments.commentable_id_=_posts.id-subject_like_%uncached post"
+                "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-nested-or-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post-exists-comments.commentable_id_=_posts.id-subject_like_%25uncached post-or-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedPost-exists-comments.commentable_id_=_posts.id-subject_like_%25uncached post"
             ))['value'];
 
         $this->assertCount(5, $comments);

--- a/tests/Integration/CachedBuilder/WhereInTest.php
+++ b/tests/Integration/CachedBuilder/WhereInTest.php
@@ -108,7 +108,7 @@ class WhereInTest extends IntegrationTestCase
 
     public function testWhereInWithPercentCharacterInValueDoesNotThrow()
     {
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-name_in_10%_20%-authors.deleted_at_null");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-name_in_10%25_20%25-authors.deleted_at_null");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",

--- a/tests/Integration/CachedBuilder/WhereJsonContainsTest.php
+++ b/tests/Integration/CachedBuilder/WhereJsonContainsTest.php
@@ -4,6 +4,8 @@ use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedAuthor;
 use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PDO;
+use Throwable;
 
 class WhereJsonContainsTest extends IntegrationTestCase
 {
@@ -22,10 +24,92 @@ class WhereJsonContainsTest extends IntegrationTestCase
 
     public function setUp() : void
     {
+        // This class runs against PostgreSQL, which SQLite cannot stand in for:
+        // its grammar refuses to compile a JSON "contains" predicate at all.
+        // The guard runs before parent::setUp() because RefreshDatabase
+        // migrates the default connection there, which is the first thing to
+        // open it — a guard placed after that never gets to speak.
+        $this->skipWithoutPostgres();
+
         parent::setUp();
 
         $this->loadMigrationsFrom(__DIR__ . '/../../database/migrations');
         Author::factory()->count(10)->create();
+    }
+
+    // Probed with a bare PDO rather than through the container, because nothing
+    // is booted yet at this point in setUp(). A missing pdo_pgsql driver throws
+    // here too, which is the same answer: this suite cannot run.
+    private function skipWithoutPostgres() : void
+    {
+        $host = env("PGSQL_HOST", "pgsql");
+        $database = env("PGSQL_DATABASE", "testing");
+
+        try {
+            new PDO(
+                "pgsql:host={$host};dbname={$database}",
+                env("PGSQL_USERNAME", "forge"),
+                env("PGSQL_PASSWORD", "secret"),
+                [PDO::ATTR_TIMEOUT => 3],
+            );
+        } catch (Throwable $exception) {
+            $this->markTestSkipped(
+                "No reachable PostgreSQL server: {$exception->getMessage()}"
+            );
+        }
+    }
+
+    private function keyPrefix() : string
+    {
+        return "genealabs:laravel-model-caching:pgsql:testing"
+            . ":authors:genealabslaravelmodelcachingtestsfixturesauthor";
+    }
+
+    private function authorTags() : array
+    {
+        return [
+            'genealabs:laravel-model-caching:pgsql:testing:genealabslaravelmodelcachingtestsfixturesauthor',
+            'genealabs:laravel-model-caching:pgsql:testing:authors',
+        ];
+    }
+
+    private function cachedValueFor(string $key)
+    {
+        return $this->cache()
+            ->tags($this->authorTags())
+            ->get($key);
+    }
+
+    // The key-level twin of this lives in WhereNotTest and runs on SQLite,
+    // because building a key touches no database. This is the half that needs a
+    // server: whereJsonContains() and whereJsonDoesntContain() shared one cache
+    // key, so the negated query was served the rows it exists to exclude.
+    public function testWhereJsonDoesntContainReturnsItsOwnResultsAfterWhereJsonContainsWasCached()
+    {
+        $containsKey = sha1($this->keyPrefix() . "-finances->total_jsoncontains_5000-authors.deleted_at_null");
+        $doesntContainKey = sha1($this->keyPrefix() . "-finances->total_not_jsoncontains_5000-authors.deleted_at_null");
+
+        $containsResults = (new Author)
+            ->whereJsonContains("finances->total", 5000)
+            ->get();
+
+        $this->assertCount(10, $containsResults);
+        $this->assertNotNull(
+            $this->cachedValueFor($containsKey),
+            "The first query must populate the cache, or the second query has nothing to collide with"
+        );
+
+        $results = (new Author)
+            ->whereJsonDoesntContain("finances->total", 5000)
+            ->get();
+        $liveResults = (new UncachedAuthor)
+            ->whereJsonDoesntContain("finances->total", 5000)
+            ->get();
+        $cachedResults = $this->cachedValueFor($doesntContainKey)['value'];
+
+        $this->assertEmpty($liveResults);
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+        $this->assertEquals($liveResults->pluck("id"), $cachedResults->pluck("id"));
     }
 
     public function testWithInUsingCollectionQuery()

--- a/tests/Integration/CachedBuilder/WhereJsonLengthTest.php
+++ b/tests/Integration/CachedBuilder/WhereJsonLengthTest.php
@@ -9,7 +9,7 @@ class WhereJsonLengthTest extends IntegrationTestCase
     public function testWithInUsingCollectionQueryNoOperator()
     {
         $length = 2;
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-finances->tags_=_$length-authors.deleted_at_null");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-finances->tags_jsonlength_=_$length-authors.deleted_at_null");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
@@ -31,7 +31,7 @@ class WhereJsonLengthTest extends IntegrationTestCase
 
     public function testWithInUsingCollectionQueryWithOperator()
     {
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-finances->tags_>_1-authors.deleted_at_null");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-finances->tags_jsonlength_>_1-authors.deleted_at_null");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",

--- a/tests/Integration/CachedBuilder/WhereNotTest.php
+++ b/tests/Integration/CachedBuilder/WhereNotTest.php
@@ -1,60 +1,202 @@
 <?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
 
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedAuthor;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
 use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
 use ReflectionMethod;
 
+// Every case here is a query whose only difference from its affirmative twin is
+// a negation — carried either by the clause's boolean ("and not") or by a
+// separate "not" flag on a shared clause type. Both used to be dropped from the
+// cache key, so the negated query read the cached rows of the query returning
+// exactly what it excludes.
+//
+// Book is deliberately the fixture: Author carries a SoftDeletes global scope,
+// and Eloquent's addNewWheresWithinGroup() rewraps existing clauses in a nested
+// group as soon as a non-"and" boolean appears, which shifts the key for
+// reasons that have nothing to do with the boolean reaching it.
 class WhereNotTest extends IntegrationTestCase
 {
+    private function cacheKey($query) : string
+    {
+        return (new ReflectionMethod($query, "makeCacheKey"))
+            ->invoke($query);
+    }
+
+    private function keyPrefix() : string
+    {
+        return "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite"
+            . ":books:genealabslaravelmodelcachingtestsfixturesbook";
+    }
+
+    private function bookTags() : array
+    {
+        return [
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+        ];
+    }
+
     public function testWhereNotProducesDifferentCacheKeyThanWhere()
     {
-        $query1 = (new Author)
-            ->where('id', 1);
+        $where = (new Book)->where("id", 1);
+        $whereNot = (new Book)->whereNot("id", 1);
 
-        $query2 = (new Author)
-            ->whereNot('id', 1);
-
-        $cacheKey1 = (new ReflectionMethod($query1, 'makeCacheKey'))
-            ->invoke($query1);
-        $cacheKey2 = (new ReflectionMethod($query2, 'makeCacheKey'))
-            ->invoke($query2);
-
-        $this->assertNotEquals($cacheKey1, $cacheKey2);
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_=_1",
+            $this->cacheKey($where)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-and_not-id_=_1",
+            $this->cacheKey($whereNot)
+        );
     }
 
     public function testWhereNotReturnsItsOwnResultsAfterWhereWasCached()
     {
-        (new Author)
-            ->where('id', 1)
-            ->get();
+        $whereQuery = (new Book)->where("id", 1);
+        $whereKey = sha1($this->cacheKey($whereQuery));
+        $whereResults = $whereQuery->get();
 
-        $results = (new Author)
-            ->whereNot('id', 1)
-            ->get();
-        $liveResults = (new UncachedAuthor)
-            ->whereNot('id', 1)
-            ->get();
+        $cachedWhereResults = $this->cache()
+            ->tags($this->bookTags())
+            ->get($whereKey);
 
-        $this->assertEquals($liveResults->pluck('id'), $results->pluck('id'));
-        $this->assertNotContains(1, $results->pluck('id')->toArray());
+        $this->assertNotNull(
+            $cachedWhereResults,
+            "The first query must populate the cache, or the second query has nothing to collide with"
+        );
+        $this->assertEquals(
+            $whereResults->pluck("id"),
+            $cachedWhereResults["value"]->pluck("id")
+        );
+
+        $results = (new Book)->whereNot("id", 1)->get();
+        $liveResults = (new UncachedBook)->whereNot("id", 1)->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+        $this->assertNotContains(1, $results->pluck("id")->toArray());
     }
 
-    public function testOrWhereProducesDifferentCacheKeyThanWhere()
+    public function testWhereNotBetweenProducesDifferentCacheKeyThanWhereBetween()
     {
-        $query1 = (new Author)
-            ->where('id', 1)
-            ->where('id', 2);
+        $between = (new Book)->whereBetween("id", [1, 2]);
+        $notBetween = (new Book)->whereNotBetween("id", [1, 2]);
 
-        $query2 = (new Author)
-            ->where('id', 1)
-            ->orWhere('id', 2);
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_between_1_2",
+            $this->cacheKey($between)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_not_between_1_2",
+            $this->cacheKey($notBetween)
+        );
+    }
 
-        $cacheKey1 = (new ReflectionMethod($query1, 'makeCacheKey'))
-            ->invoke($query1);
-        $cacheKey2 = (new ReflectionMethod($query2, 'makeCacheKey'))
-            ->invoke($query2);
+    public function testWhereNotBetweenReturnsItsOwnResultsAfterWhereBetweenWasCached()
+    {
+        $betweenQuery = (new Book)->whereBetween("id", [1, 2]);
+        $betweenKey = sha1($this->cacheKey($betweenQuery));
+        $betweenResults = $betweenQuery->get();
 
-        $this->assertNotEquals($cacheKey1, $cacheKey2);
+        $cachedBetweenResults = $this->cache()
+            ->tags($this->bookTags())
+            ->get($betweenKey);
+
+        $this->assertNotNull(
+            $cachedBetweenResults,
+            "The first query must populate the cache, or the second query has nothing to collide with"
+        );
+        $this->assertEquals(
+            $betweenResults->pluck("id"),
+            $cachedBetweenResults["value"]->pluck("id")
+        );
+
+        $results = (new Book)->whereNotBetween("id", [1, 2])->get();
+        $liveResults = (new UncachedBook)->whereNotBetween("id", [1, 2])->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+        $this->assertEmpty(array_intersect([1, 2], $results->pluck("id")->toArray()));
+    }
+
+    // The JSON families need a real JSON column, which only the authors table
+    // has. Author's SoftDeletes global scope is harmless here — it adds one
+    // fixed clause to the key, and unlike the "or" cases it never triggers
+    // addNewWheresWithinGroup(), because a "not" flag is not a boolean.
+    private function authorKeyPrefix() : string
+    {
+        return "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite"
+            . ":authors:genealabslaravelmodelcachingtestsfixturesauthor";
+    }
+
+    private function authorTags() : array
+    {
+        return [
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
+        ];
+    }
+
+    // whereJsonContains() gets no result-level twin: SQLite cannot compile a
+    // JSON "contains" predicate at all, and the suite's PostgreSQL-backed JSON
+    // tests are skipped unless that server is running. The key is built without
+    // touching the database, and the key is where the defect lived.
+    public function testWhereJsonDoesntContainProducesDifferentCacheKeyThanWhereJsonContains()
+    {
+        $contains = (new Author)->whereJsonContains("finances->total", 5000);
+        $doesntContain = (new Author)->whereJsonDoesntContain("finances->total", 5000);
+
+        $this->assertEquals(
+            $this->authorKeyPrefix() . "-finances->total_jsoncontains_5000-authors.deleted_at_null",
+            $this->cacheKey($contains)
+        );
+        $this->assertEquals(
+            $this->authorKeyPrefix() . "-finances->total_not_jsoncontains_5000-authors.deleted_at_null",
+            $this->cacheKey($doesntContain)
+        );
+    }
+
+    public function testWhereJsonDoesntContainKeyProducesDifferentCacheKeyThanWhereJsonContainsKey()
+    {
+        $containsKey = (new Author)->whereJsonContainsKey("finances->total");
+        $doesntContainKey = (new Author)->whereJsonDoesntContainKey("finances->total");
+
+        $this->assertEquals(
+            $this->authorKeyPrefix() . "-finances->total_jsoncontainskey_-authors.deleted_at_null",
+            $this->cacheKey($containsKey)
+        );
+        $this->assertEquals(
+            $this->authorKeyPrefix() . "-finances->total_not_jsoncontainskey_-authors.deleted_at_null",
+            $this->cacheKey($doesntContainKey)
+        );
+    }
+
+    public function testWhereJsonContainsKeyReturnsItsOwnResultsAfterWhereJsonDoesntContainKeyWasCached()
+    {
+        $doesntContainKeyQuery = (new Author)->whereJsonDoesntContainKey("finances->total");
+        $doesntContainKeyKey = sha1($this->cacheKey($doesntContainKeyQuery));
+        $doesntContainKeyResults = $doesntContainKeyQuery->get();
+
+        $cachedResults = $this->cache()
+            ->tags($this->authorTags())
+            ->get($doesntContainKeyKey);
+
+        $this->assertNotNull(
+            $cachedResults,
+            "The first query must populate the cache, or the second query has nothing to collide with"
+        );
+        $this->assertEquals(
+            $doesntContainKeyResults->pluck("id"),
+            $cachedResults["value"]->pluck("id")
+        );
+
+        $results = (new Author)->whereJsonContainsKey("finances->total")->get();
+        $liveResults = (new UncachedAuthor)->whereJsonContainsKey("finances->total")->get();
+
+        $this->assertNotEmpty($results);
+        $this->assertEmpty($doesntContainKeyResults);
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
     }
 }

--- a/tests/Integration/CachedBuilder/WhereRawTest.php
+++ b/tests/Integration/CachedBuilder/WhereRawTest.php
@@ -14,7 +14,7 @@ class WhereRawTest extends IntegrationTestCase
             ->whereRaw('name <> \'\'')
             ->first()]);
 
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-_and_name_<>_''-authors.deleted_at_null-first");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-name_<>_''-authors.deleted_at_null-first");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
@@ -37,7 +37,7 @@ class WhereRawTest extends IntegrationTestCase
             ->whereRaw("name != 'test3'")
             ->whereRaw('name = ? AND name != ?', [$authorName, "test2"])
             ->get();
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-name_!=_test-_and_name_!=_'test3'-_and_name_=_" . str_replace(" ", "_", $authorName) . "__AND_name_!=_test2-authors.deleted_at_null");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-name_!=_test-name_!=_'test3'-name_=_" . str_replace(" ", "_", $authorName) . "_AND_name_!=_test2-authors.deleted_at_null");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
@@ -111,8 +111,8 @@ class WhereRawTest extends IntegrationTestCase
         $result2 = (new Book)
             ->whereRaw("id = ?", [$book2->id])
             ->get();
-        $key1 = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-_and_id_=_{$book1->id}");
-        $key2 = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-_and_id_=_{$book2->id}");
+        $key1 = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-id_=_{$book1->id}");
+        $key2 = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-id_=_{$book2->id}");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
@@ -137,8 +137,8 @@ class WhereRawTest extends IntegrationTestCase
             ->where("id", ">", 1)
             ->whereRaw("id = ?", [$book2->id])
             ->get();
-        $key1 = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-id_>_0-_and_id_=_{$book1->id}");
-        $key2 = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-id_>_1-_and_id_=_{$book2->id}");
+        $key1 = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-id_>_0-id_=_{$book1->id}");
+        $key2 = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-id_>_1-id_=_{$book2->id}");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",

--- a/tests/Integration/CachedBuilder/WhereTest.php
+++ b/tests/Integration/CachedBuilder/WhereTest.php
@@ -119,7 +119,7 @@ class WhereTest extends IntegrationTestCase
 
     public function testWhereUsesCorrectBinding()
     {
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-nested-name_like_B%-or-name_like_G%-authors.deleted_at_null");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-nested-name_like_B%25-or-name_like_G%25-authors.deleted_at_null");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",

--- a/tests/Integration/CachedBuilder/WhereValueEscapingTest.php
+++ b/tests/Integration/CachedBuilder/WhereValueEscapingTest.php
@@ -1,0 +1,220 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use ReflectionMethod;
+
+// The key format joins its segments with "-" and "_". A value containing either
+// used to be written into the key raw, so it could spell out a different query's
+// clauses and read that query's cached rows.
+class WhereValueEscapingTest extends IntegrationTestCase
+{
+    private function cacheKey($query) : string
+    {
+        return (new ReflectionMethod($query, "makeCacheKey"))
+            ->invoke($query);
+    }
+
+    private function keyPrefix() : string
+    {
+        return "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite"
+            . ":books:genealabslaravelmodelcachingtestsfixturesbook";
+    }
+
+    public function testValueContainingSeparatorsDoesNotCollideWithTwoSeparateClauses()
+    {
+        $oneValue = (new Book)->where("title", "a-title_=_b");
+        $twoClauses = (new Book)->where("title", "a")->where("title", "b");
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_=_a%2Dtitle%5F=%5Fb",
+            $this->cacheKey($oneValue)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_=_a-title_=_b",
+            $this->cacheKey($twoClauses)
+        );
+        $this->assertNotEquals(
+            $this->cacheKey($oneValue),
+            $this->cacheKey($twoClauses)
+        );
+    }
+
+    public function testValueContainingSeparatorsReturnsItsOwnResultsAfterTheCollidingQueryWasCached()
+    {
+        $book = (new UncachedBook)->first();
+        $book->title = "a-title_=_b";
+        $book->save();
+
+        $collidingQuery = (new Book)->where("title", "a")->where("title", "b");
+        $collidingKey = sha1($this->cacheKey($collidingQuery));
+        $collidingResults = $collidingQuery->get();
+        $tags = [
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+        ];
+
+        $cached = $this->cache()
+            ->tags($tags)
+            ->get($collidingKey);
+
+        $this->assertNotNull(
+            $cached,
+            "The first query must populate the cache, or the second query has nothing to collide with"
+        );
+        $this->assertEmpty($collidingResults);
+
+        $results = (new Book)->where("title", "a-title_=_b")->get();
+        $liveResults = (new UncachedBook)->where("title", "a-title_=_b")->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($liveResults->pluck("id"), $results->pluck("id"));
+    }
+
+    // "%" is the escape character, so it has to be escaped too, or the encoding
+    // is not reversible: the value "a%2Db" and the value "a-b" would both come
+    // out as "a%2Db" and share a key.
+    public function testPercentIsEscapedSoTheEncodingStaysReversible()
+    {
+        $literal = (new Book)->where("title", "a%2Db");
+        $separator = (new Book)->where("title", "a-b");
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_=_a%252Db",
+            $this->cacheKey($literal)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_=_a%2Db",
+            $this->cacheKey($separator)
+        );
+        $this->assertNotEquals(
+            $this->cacheKey($literal),
+            $this->cacheKey($separator)
+        );
+    }
+
+    // Nothing else here would fail if the encoding were rewritten to replace
+    // its pairs sequentially with "%" reached last, which would encode the "%"
+    // of every "%2D" it had just written and turn "-" into "%252D". This pins
+    // the output against that. Verified by mutation: swapping strtr() for such
+    // a loop reddens this test, and reordering the pairs is what does it.
+    public function testSeparatorEncodingIsNotDoubleEncoded()
+    {
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_=_a%2Db%5Fc%25d",
+            $this->cacheKey((new Book)->where("title", "a-b_c%d"))
+        );
+    }
+
+    // The escaping only rewrites the three characters above, so a value holding
+    // none of them keeps the exact bytes it had before — no existing cache entry
+    // for an ordinary value goes cold on upgrade.
+    public function testKeysForValuesWithoutSeparatorsAreUnchanged()
+    {
+        $cases = [
+            "a" => "-title_=_a",
+            "plain title" => "-title_=_plain title",
+            "Ünïcödé" => "-title_=_Ünïcödé",
+            "0" => "-title_=_0",
+            "a.b:c/d" => "-title_=_a.b:c/d",
+        ];
+
+        foreach ($cases as $value => $expectedClause) {
+            $this->assertEquals(
+                $this->keyPrefix() . $expectedClause,
+                $this->cacheKey((new Book)->where("title", (string) $value)),
+                "The key for the value {$value} must not change"
+            );
+        }
+    }
+
+    public function testBothBetweenBoundsAreEscaped()
+    {
+        $query = (new Book)->whereBetween("title", ["a-b", "c_d"]);
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_between_a%2Db_c%5Fd",
+            $this->cacheKey($query)
+        );
+    }
+
+    public function testRowValuesAreEscaped()
+    {
+        $query = (new Book)->whereRowValues(["title", "description"], "=", ["a-b", "c_d"]);
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_description_=_a%2Db_c%5Fd",
+            $this->cacheKey($query)
+        );
+    }
+
+    // "_" joins the values of an "in" clause, so one value containing "_" spelt
+    // out two values and shared their key.
+    public function testWhereInValuesAreEscaped()
+    {
+        $oneValue = (new Book)->whereIn("title", ["1_2"]);
+        $twoValues = (new Book)->whereIn("title", ["1", "2"]);
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_in_1%5F2",
+            $this->cacheKey($oneValue)
+        );
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_in_1_2",
+            $this->cacheKey($twoValues)
+        );
+        $this->assertNotEquals(
+            $this->cacheKey($oneValue),
+            $this->cacheKey($twoValues)
+        );
+    }
+
+    public function testWhereNotInValuesAreEscaped()
+    {
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_notin_a%2Db",
+            $this->cacheKey((new Book)->whereNotIn("title", ["a-b"]))
+        );
+    }
+
+    // The third return path of getInAndNotInClauses(), reached when a value
+    // contains "?": that path treats the "?" as a placeholder and rebuilds the
+    // clause by substituting bindings for it. Both the value and the
+    // substituted binding land in the key, so both are escaped.
+    //
+    // The repeated fragment in the expected key is that substitution folding
+    // the value back into itself. It is pre-existing behaviour of this path,
+    // not something the escaping introduced; it is pinned here rather than
+    // corrected, because rewriting that path is not what this change is for.
+    public function testWhereInValuesContainingAPlaceholderAreEscaped()
+    {
+        $key = $this->cacheKey((new Book)->whereIn("title", ["a_b?c"]));
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-title_in_a%5Fba%5Fb?cc",
+            $key
+        );
+        $this->assertStringNotContainsString("_b?c", $key);
+    }
+
+    // The binary-UUID branch of getInAndNotInClauses() recognises its value by
+    // being exactly 16 bytes long. Escaping runs below that branch precisely so
+    // a 0x2D or 0x5F byte inside a UUID cannot stretch it past 16 and send it
+    // down the wrong path. This UUID contains both bytes.
+    public function testBinaryUuidWhereInValueIsNotEscaped()
+    {
+        $uuid = Uuid::fromString("2d5f2d5f-2d5f-4d5f-8d5f-2d5f2d5f2d5f");
+        $bytes = $uuid->getBytes();
+
+        $this->assertSame(16, strlen($bytes));
+        $this->assertStringContainsString("-", $bytes);
+        $this->assertStringContainsString("_", $bytes);
+
+        $this->assertEquals(
+            $this->keyPrefix() . "-id_in_{$uuid->toString()}",
+            $this->cacheKey((new Book)->whereIn("id", [$bytes]))
+        );
+    }
+}

--- a/tests/Integration/CachedBuilderRelationshipsTest.php
+++ b/tests/Integration/CachedBuilderRelationshipsTest.php
@@ -12,7 +12,7 @@ class CachedBuilderRelationshipsTest extends IntegrationTestCase
             ->with("stores")
             ->has("stores")
             ->get();
-        $key = "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-exists-and_books.id_=_book_store.book_id-testing:{$this->testingSqlitePath}testing.sqlite:stores";
+        $key = "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-exists-books.id_=_book_store.book_id-testing:{$this->testingSqlitePath}testing.sqlite:stores";
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesstore",

--- a/tests/Integration/CachedBuilderTest.php
+++ b/tests/Integration/CachedBuilderTest.php
@@ -508,7 +508,7 @@ class CachedBuilderTest extends IntegrationTestCase
         $authors = (new Author)->whereHas('books')
             ->get();
 
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-exists-and_authors.id_=_books.author_id-authors.deleted_at_null");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-exists-authors.id_=_books.author_id-authors.deleted_at_null");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
@@ -530,7 +530,7 @@ class CachedBuilderTest extends IntegrationTestCase
             ->doesntHave('books')
             ->get();
 
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-notexists-and_authors.id_=_books.author_id-authors.deleted_at_null");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors:genealabslaravelmodelcachingtestsfixturesauthor-notexists-authors.id_=_books.author_id-authors.deleted_at_null");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
@@ -649,7 +649,7 @@ class CachedBuilderTest extends IntegrationTestCase
         $books = (new Book)
             ->whereBetween('created_at', ['2018-01-01', '2018-12-31'])
             ->get();
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-created_at_between_2018-01-01_2018-12-31");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-created_at_between_2018%2D01%2D01_2018%2D12%2D31");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
@@ -671,7 +671,7 @@ class CachedBuilderTest extends IntegrationTestCase
         $books = (new Book)
             ->whereDate('created_at', '>=', '2018-01-01')
             ->get();
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-created_at_>=_2018-01-01");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-created_at_date_>=_2018%2D01%2D01");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",

--- a/tests/Integration/CachedModelTest.php
+++ b/tests/Integration/CachedModelTest.php
@@ -117,7 +117,7 @@ class CachedModelTest extends IntegrationTestCase
             })
             ->get();
 
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-exists-and_books.author_id_=_authors.id-id_=_1-authors.deleted_at_null-testing:{$this->testingSqlitePath}testing.sqlite:author");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook-exists-books.author_id_=_authors.id-id_=_1-authors.deleted_at_null-testing:{$this->testingSqlitePath}testing.sqlite:author");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",


### PR DESCRIPTION
Fixes #616

Closes every item collected from the reviews of #615, #614 and #613. The three
merged PRs each fix the defect they name; none closes the wider problem around
it. This closes those.

## What changed

**Cache keys — one format, one boolean rule (Parts 1 and 3).** `getColumnClauses()`,
`getRowValuesClauses()`, `getRawClauses()`, `getNestedClauses()` and
`getInAndNotInClauses()` now emit the boolean the way `getOtherClauses()` does:
nothing for the default `and`, a `-{boolean}` prefix otherwise. The rule lives in
one new `getBooleanSlug()` helper, so the next clause family added cannot pick a
fourth format. Five families that used to hand `orWhere…` the cached rows of
`where…` no longer share a key.

**Clause identity — the hard-coded type list is now a rule (Part 1, plus one
family found during implementation).** `getTypeClause()` matched
`$where["type"]` against a hard-coded list of eleven names, using the type for a
listed clause and `$where["operator"]` for everything else. That list was wrong
in both directions:

- Four operator-less types Laravel added after it was written —
  `betweenColumns`, `valueBetween`, `Like`, `JsonOverlaps` — fell through to a
  key that is not there and raised `Undefined array key "operator"`, which
  Laravel's default handler turns into an `ErrorException`.
- Eight types that *do* carry an operator were also unlisted, so each was named
  by its operator alone and lost its identity: `Date`, `Day`, `Month`, `Year`,
  `Time`, `Sub`, `JsonLength` and `JsonBoolean`.

The list is now a rule: **a clause names itself by its type, and adds its
operator when it carries one — except `Basic`, which names itself by its
operator alone.** That single exception is what holds the no-cold-cache
constraint: a plain `where()` renders exactly as it did, byte for byte. Every
type the old list named is operator-less, so those reproduce byte for byte too.
The `not` flag is read as well, so `whereNotBetween()` no longer shares a key
with `whereBetween()`.

Stating the rule rather than extending the list is deliberate. The list is what
put this file in two holes at once; a twelfth entry would have left the
thirteenth type Laravel adds in the same place.

**Value escaping (Part 3).** `where("title", "a-title_=_b")` built the same key as
`where("title", "a")->where("title", "b")`, because `-` and `_` separate key
segments and are legal inside values. Values now carry those characters
percent-encoded, and `%` with them — an encoding whose own escape character is
unescaped is not reversible, so `"a%2Db"` and `"a-b"` would still collide.

`whereIn()` values are escaped too. The encoding runs *below* the branch that
recognises a raw binary UUID, which identifies its value by being exactly 16
bytes long: encoding a `0x2D` or `0x5F` byte inside one would stretch it past 16
and send the value down the wrong path. All three return paths of
`getInAndNotInClauses()` are covered, including the one that substitutes
bindings for a `?` inside a value.

**Subquery join tags (Part 4).** `joinSub()` compiles its subquery to SQL and
hands `join()` an `Expression`, so by the time `CacheTags` runs there is no table
name left and a write to the joined table did not invalidate the cached query.

A new `CachedQueryBuilder` — the `Illuminate\Database\Query\Builder` layer, not
the Eloquent one — records the subquery's `from` before Laravel compiles it, for
`joinSub()`, `leftJoinSub()`, `rightJoinSub()`, `joinLateral()`,
`leftJoinLateral()`, and Closure subqueries through a wrapper that keeps the
caller's callback running exactly once. `ModelCaching::newBaseQueryBuilder()`
returns it. `getJoinTags()` emits those tables alongside the string ones and
filters on an explicit `null`.

It has to be the query-builder layer. Eloquent defers some of its own subquery
joins into a `beforeQuery()` callback — `ofMany()` is the one in Laravel — and
that callback is invoked with the query builder, never with the Eloquent builder
wrapping it, so a hook on `CachedBuilder` never sees the join. A hook there was
tried first and could not reach it; the probe is in the commit body.

Tags are also made *before* the query runs, so those callbacks have not fired and
there is nothing recorded yet. `CacheTags` materializes them on a clone to read
the tables, leaving the query that will actually execute untouched — the same
trade `CacheKey` already makes to build a key for an `ofMany()` query.

**A consumer's own base query builder is never replaced.** The swap happens only
when `parent::newBaseQueryBuilder()` returns Laravel's own class. Recording one
more table to tag is worth far less than silently substituting a builder someone
else depends on. `AuthorWithCustomBaseBuilder` is a new fixture covering exactly
that: the repo's existing custom-builder fixtures are all *Eloquent* builders,
and none of them touch this layer.

**Pagination (Part 5).** `CachesOneOrManyThrough::paginate()` dropped its inert
`$total`, and the parameter is gone. Its regression test now reaches
`Buildable::paginate()` and asserts no `count(*)` runs.

### The date family — found while implementing, folded in rather than deferred

The type-clause work above surfaced a collision set that #616 does not list. It
is not caused by this PR: the old hard-coded list did not name `Date`, `Day`,
`Month`, `Year` or `Time` either, so they always fell through to the operator.
It is the same defect class as Part 1 — queries that return different rows
sharing one cache key — so it is fixed here rather than tracked separately.

| Query | Key segment before | Key segment now |
| --- | --- | --- |
| `where('published_at', '=', '2020-01-05')` | `_=_2020%2D01%2D05` | `_=_2020%2D01%2D05` (unchanged) |
| `whereDate('published_at', '=', '2020-01-05')` | `_=_2020%2D01%2D05` | `_date_=_2020%2D01%2D05` |
| `where('published_at', '=', 5)` | `_=_5` | `_=_5` (unchanged) |
| `whereDay('published_at', 5)` | `_=_05` | `_day_=_05` |
| `whereMonth('published_at', 5)` | `_=_05` | `_month_=_05` |
| `whereYear('published_at', 5)` | `_=_5` | `_year_=_5` |
| `whereTime('published_at', '=', 5)` | `_=_5` | `_time_=_5` |

`whereDay` and `whereMonth` were the worst pair: Laravel zero-pads both bindings
to `05`, so the keys matched byte for byte. `whereYear` matched both `whereTime`
and a plain `where`.

Grepping `Query\Builder` for what it puts in `$where["type"]` rather than
assuming the date family was the whole set found three more clauses with the
same shape — a type outside the old list that carries an operator:

- **`JsonLength`** — `whereJsonLength('a->b', '>', 1)` shared a key with
  `where('a->b', '>', 1)`. Different SQL, different rows.
- **`Sub`** — `where('id', '=', fn ($q) => …)` shared a key with
  `where('id', '=', $value)` whenever the bindings lined up.
- **`JsonBoolean`** — `where('opts->x', true)` compiles the value to a raw
  `true` expression, and shared a key with `where('opts->x', 'true')`, which
  binds the string.

Two further types are renamed by the rule without ever having collided:
`Bitwise` and `NullSafeEquals`. Both are reachable only through an operator that
no `Basic` clause can carry, so they were already distinct. Their keys change
anyway, because the rule is stated once rather than carved with exceptions —
listed in the release note below.

## Release note — cache keys that go cold once on upgrade

These are correct changes, not regressions. Each cached query below misses once
and then repopulates.

- **Negated clause families.** `whereNotBetween()`, `whereNotBetweenColumns()`,
  `whereJsonDoesntContain()`, `whereJsonDoesntContainKey()`,
  `whereJsonDoesntOverlap()`, `whereNotLike()`, `whereValueNotBetween()` — their
  keys were wrong before, identical to the affirmative query.
- **Column clauses.** `-and_{first}_{op}_{second}` is now
  `-{first}_{op}_{second}`. Affects every `whereColumn()` and every relation
  constraint built from one, which includes `whereHas()` and `has()`.
- **Raw clauses.** `-_{boolean}_{sql}` is now `-{sql}`, with each binding
  substituted in place of its `?` instead of appended after it.
- **Row-value clauses.** `-and_{cols}_{op}_{vals}` is now `-{cols}_{op}_{vals}`.
- **Nested and `in` clauses with a non-`and` boolean.** `orWhere(Closure)`,
  `orWhereHas()`, `orWhereIn()` and siblings now carry `-or`. They previously
  shared the `and` query's key, which is the bug.
- **The date family.** Every cached `whereDate()`, `whereDay()`, `whereMonth()`,
  `whereYear()` and `whereTime()` query goes cold once. Their keys were wrong
  before — identical to a plain `where()` on the same column and value, and in
  the `whereDay`/`whereMonth` case identical to each other.
- **`whereJsonLength()`, `whereSub()` (a Closure passed as a `where` value), and
  `where()` on a JSON path with a boolean value.** Same cause, same correction.
- **`Bitwise` and `NullSafeEquals` clauses** — `where('flags', '&', 1)` and
  `where('a', '<=>', $b)`. These never collided; they change because the naming
  rule is stated once instead of carved with exceptions.
- **Any cached query joining a subquery** now carries one more tag — the table
  that subquery reads. Its key is unchanged; only the tag set grows, so the
  entry is not cold, it is merely invalidated by more writes than before. That
  is the fix.
- **Any query whose values contain `-`, `_` or `%`.** Most visibly dates —
  `whereDate("created_at", ">=", "2018-01-01")` keys as `2018%2D01%2D01` — and
  every `LIKE` pattern, since `where("name", "like", "A%")` keys as `A%25`.
  `whereIn()` values are included.

Keys for plain `where()` with a value containing neither separator are unchanged,
byte for byte. Two tests pin that rather than leaving it asserted in prose:
`WhereValueEscapingTest::testKeysForValuesWithoutSeparatorsAreUnchanged` for the
value, and `WhereDateFamilyTest::testPlainWhereKeyIsUnchanged` for the clause.

## Acceptance criteria

Cache keys:

- [x] `where(Closure)` and `orWhere(Closure)` produce different cache keys.
- [x] `whereHas()` and `orWhereHas()` produce different cache keys.
- [x] `whereIn()` and `orWhereIn()` produce different cache keys. Same for `whereNotIn`/`orWhereNotIn` and `whereIntegerInRaw`.
- [x] `whereBetween()` and `whereNotBetween()` produce different cache keys.
- [x] `whereJsonContains()` and `whereJsonDoesntContain()` produce different cache keys. Same for `whereJsonContainsKey()` and `whereJsonDoesntContainKey()`.
- [x] `whereBetweenColumns()` produces a cache key and raises no PHP warning. `whereNotBetweenColumns()` produces a different key.
- [x] Cache keys for the default `and` case are unchanged, so plain `where()` queries do not go cold on upgrade.

Tests:

- [x] `testOrWhereProducesDifferentCacheKeyThanWhere` is rewritten against a fixture with no global scope, or asserts the exact `sha1(...)` key. It must fail on the source that predates #615.
- [x] Each family above has a test that asserts the exact `sha1(...)` key string, and a second test that proves the second query returns its own rows after the first query populated the cache.
- [x] The result-level tests assert that the first query was in fact cached, so a caching no-op cannot pass them.
- [x] Every new test fails before its fix. A test that passes without the source change proves nothing.
- [x] `WhereNotTest.php` holds only `whereNot` cases, or is renamed to match what it covers.

Join tags:

- [x] A `joinSub()` query tags the table its subquery reads from, so a write to that table invalidates the cached query.
- [x] An `ofMany()` relation builds its tags without raising a `TypeError`, including when the relation was executed before the tags are made.
- [x] `testJoinSubQueryResultsAreCached` asserts that the query was in fact cached.
- [x] `getJoinTags()` filters on an explicit `null` check rather than truthiness.

Pagination:

- [x] `testUncachedPaginationHonorsProvidedTotal` is rewritten against a construction that reaches `Buildable::paginate()` with `isCachable()` false. It must fail on the source that predates #613.
- [x] That test also asserts no `count(*)` query runs when a total is supplied.
- [x] `CachesOneOrManyThrough::paginate()` drops its inert `$total` parameter, or carries a comment saying why Laravel cannot honor it.

Structure:

- [x] The clause formats in `CacheKey.php` are unified.
- [x] A decision is recorded on value escaping.
- [x] The full suite passes.

## Test plan

`vendor/bin/phpunit` on PHP 8.5 / macOS / SQLite / Redis.

| | tests | assertions | skipped |
| --- | --- | --- | --- |
| `master` (511bf4e) | 414 | 1063 | 4 |
| this branch | 465 | 1206 | 4 |

The `WhereJsonContainsTest` class runs against PostgreSQL and now skips cleanly
when no server is reachable, rather than erroring. Verified in both directions on
this machine: 3 pass against a live server, 3 skip with an unreachable host. Its
guard runs before `parent::setUp()`, because `RefreshDatabase` migrates the
default connection there and that is what first opens it — a guard placed after
never gets to speak. It probes with a bare PDO, since nothing is booted yet.

24 existing tests asserted a literal `sha1(...)` of the old key format. Each
literal was rewritten by applying the documented format rule by hand, not by
copying what the new code prints: 7 for the column-clause format, 5 for the raw
format, 4 for date values gaining `%2D`, 2 for `whereJsonLength` gaining its type
segment, 6 for `LIKE` patterns gaining `%25`. Three `whereHasMorph` keys gained
`-or`, which is the nested-boolean fix reaching the key.
`CachedBuilderTest::testWhereDatesResults` changed twice: once for the escaped
date value, once for the `date_` type segment.

## Pre-fix mutation check

Every new and rewritten test was run with the pre-fix source restored into the
branch and confirmed red before the branch version was put back. Two of the three
PRs this follows up shipped a test that passed on unmodified `master`; this is the
check that catches that.

The baseline differs per test, because `master` already carries #613, #614 and
#615. A test guarding one of those fixes is checked against the commit that
predates it.

| Test | Pre-fix source | Result |
| --- | --- | --- |
| `WhereNotTest::testWhereNotProducesDifferentCacheKeyThanWhere` | `a294cf7:src/CacheKey.php` (pre-#615) | red |
| `WhereNotTest::testWhereNotReturnsItsOwnResultsAfterWhereWasCached` | `a294cf7:src/CacheKey.php` (pre-#615) | red |
| `WhereNotTest::testWhereNotBetweenProducesDifferentCacheKeyThanWhereBetween` | `master:src/CacheKey.php` | red |
| `WhereNotTest::testWhereNotBetweenReturnsItsOwnResultsAfterWhereBetweenWasCached` | `master:src/CacheKey.php` | red |
| `WhereNotTest::testWhereJsonDoesntContainProducesDifferentCacheKeyThanWhereJsonContains` | `master:src/CacheKey.php` | red |
| `WhereNotTest::testWhereJsonDoesntContainKeyProducesDifferentCacheKeyThanWhereJsonContainsKey` | `master:src/CacheKey.php` | red |
| `WhereNotTest::testWhereJsonContainsKeyReturnsItsOwnResultsAfterWhereJsonDoesntContainKeyWasCached` | `master:src/CacheKey.php` | red |
| `OrWhereTest::testOrWhereProducesDifferentCacheKeyThanWhere` | `a294cf7:src/CacheKey.php` (pre-#615) | red |
| `OrWhereTest::testOrWhereReturnsItsOwnResultsAfterWhereWasCached` | `a294cf7:src/CacheKey.php` (pre-#615) | red |
| `OrWhereTest::testOrWhereClosureProducesDifferentCacheKeyThanWhereClosure` | `master:src/CacheKey.php` | red |
| `OrWhereTest::testOrWhereClosureReturnsItsOwnResultsAfterWhereClosureWasCached` | `master:src/CacheKey.php` | red |
| `OrWhereTest::testOrWhereHasProducesDifferentCacheKeyThanWhereHas` | `master:src/CacheKey.php` | red |
| `OrWhereTest::testOrWhereHasReturnsItsOwnResultsAfterWhereHasWasCached` | `master:src/CacheKey.php` | red |
| `OrWhereTest::testOrWhereInProducesDifferentCacheKeyThanWhereIn` | `master:src/CacheKey.php` | red |
| `OrWhereTest::testOrWhereInReturnsItsOwnResultsAfterWhereInWasCached` | `master:src/CacheKey.php` | red |
| `OrWhereTest::testOrWhereNotInProducesDifferentCacheKeyThanWhereNotIn` | `master:src/CacheKey.php` | red |
| `OrWhereTest::testOrWhereNotInReturnsItsOwnResultsAfterWhereNotInWasCached` | `master:src/CacheKey.php` | red |
| `OrWhereTest::testOrWhereIntegerInRawProducesDifferentCacheKeyThanWhereIntegerInRaw` | `master:src/CacheKey.php` | red |
| `OrWhereTest::testOrWhereIntegerInRawReturnsItsOwnResultsAfterWhereIntegerInRawWasCached` | `master:src/CacheKey.php` | red |
| `WhereBetweenColumnsTest::testWhereBetweenColumnsProducesACacheKeyWithoutRaisingAWarning` | `master:src/CacheKey.php` | red (`ErrorException`) |
| `WhereBetweenColumnsTest::testWhereNotBetweenColumnsProducesADifferentCacheKey` | `master:src/CacheKey.php` | red (`ErrorException`) |
| `WhereBetweenColumnsTest::testWhereBetweenColumnsReturnsRowsRatherThanThrowing` | `master:src/CacheKey.php` | red (`ErrorException`) |
| `WhereBetweenColumnsTest::testWhereNotBetweenColumnsReturnsItsOwnResultsAfterWhereBetweenColumnsWasCached` | `master:src/CacheKey.php` | red (`ErrorException`) |
| `WhereValueEscapingTest::testValueContainingSeparatorsDoesNotCollideWithTwoSeparateClauses` | `master:src/CacheKey.php` | red |
| `WhereValueEscapingTest::testValueContainingSeparatorsReturnsItsOwnResultsAfterTheCollidingQueryWasCached` | `master:src/CacheKey.php` | red |
| `WhereValueEscapingTest::testBothBetweenBoundsAreEscaped` | `master:src/CacheKey.php` | red |
| `WhereValueEscapingTest::testRowValuesAreEscaped` | `master:src/CacheKey.php` | red |
| `WhereValueEscapingTest::testKeysForValuesWithoutSeparatorsAreUnchanged` | `master:src/CacheKey.php` | **green — by design** |
| `JoinCacheInvalidationTest::testJoinSubQueryCacheTagsContainTheSubqueryTableTag` | `master` CacheTags + CachedBuilder + Caching | red |
| `JoinCacheInvalidationTest::testLeftJoinSubQueryCacheTagsContainTheSubqueryTableTag` | `master` CacheTags + CachedBuilder + Caching | red |
| `JoinCacheInvalidationTest::testJoinSubQueryCacheTagsContainTheSubqueryTableTagForAClosureSubquery` | `master` CacheTags + CachedBuilder + Caching | red |
| `JoinCacheInvalidationTest::testJoinSubQueryCacheIsInvalidatedWhenTheSubqueryTableIsWritten` | `master` CacheTags + CachedBuilder + Caching | red |
| `JoinCacheInvalidationTest::testJoinSubQueryResultsAreCached` | `aa28fb4:src/CacheTags.php` (pre-#614) | red (`TypeError`) |
| `JoinCacheInvalidationTest::testOfManyRelationBuildsCacheTagsWithoutRaisingATypeError` | `aa28fb4:src/CacheTags.php` (pre-#614) | red (`TypeError`) |
| `PaginateTest::testUncachedPaginationHonorsProvidedTotal` | `aa28fb4:src/Traits/Buildable.php` (pre-#613) | red |
| `PaginateTest::testHasManyThroughPaginationIsCached` | key differentiator in `CachesOneOrManyThrough::paginate()` mutated | red |
| `WhereDateFamilyTest::testWhereDateProducesADifferentCacheKeyThanWhere` | branch with `getTypeClause()` reverted | red |
| `WhereDateFamilyTest::testWhereDayProducesADifferentCacheKeyThanWhereMonth` | branch with `getTypeClause()` reverted | red |
| `WhereDateFamilyTest::testWhereYearWhereTimeAndWhereProduceThreeDifferentCacheKeys` | branch with `getTypeClause()` reverted | red |
| `WhereDateFamilyTest::testWhereDateReturnsItsOwnResultsAfterWhereWasCached` | branch with `getTypeClause()` reverted | red |
| `WhereDateFamilyTest::testWhereMonthReturnsItsOwnResultsAfterWhereDayWasCached` | branch with `getTypeClause()` reverted | red |
| `WhereDateFamilyTest::testWhereTimeReturnsItsOwnResultsAfterWhereYearWasCached` | branch with `getTypeClause()` reverted | red |
| `WhereDateFamilyTest::testWhereJsonLengthProducesADifferentCacheKeyThanWhere` | branch with `getTypeClause()` reverted | red |
| `WhereDateFamilyTest::testWhereSubProducesADifferentCacheKeyThanWhere` | branch with `getTypeClause()` reverted | red |
| `WhereDateFamilyTest::testPlainWhereKeyIsUnchanged` | branch with `getTypeClause()` reverted | **green — by design** |
| `WhereValueEscapingTest::testPercentIsEscapedSoTheEncodingStaysReversible` | branch without `"%"` in the escape map | red |
| `WhereValueEscapingTest::testSeparatorEncodingIsNotDoubleEncoded` | branch without `"%"` in the escape map | red |
| `WhereValueEscapingTest::testWhereInValuesAreEscaped` | branch without the `whereIn` escaping | red |
| `WhereValueEscapingTest::testWhereNotInValuesAreEscaped` | branch without the `whereIn` escaping | red |
| `WhereValueEscapingTest::testWhereInValuesContainingAPlaceholderAreEscaped` | branch without the `whereIn` escaping | red |
| `WhereValueEscapingTest::testBinaryUuidWhereInValueIsNotEscaped` | branch without the `whereIn` escaping | **green — by design** |
| `WhereJsonContainsTest::testWhereJsonDoesntContainReturnsItsOwnResultsAfterWhereJsonContainsWasCached` | `master:src/CacheKey.php` | red |
| `JoinCacheInvalidationTest::testDeferredJoinSubQueryCacheTagsContainTheSubqueryTableTag` | base builder never swapped in | red |
| `JoinCacheInvalidationTest::testDeferredJoinSubQueryCacheIsInvalidatedWhenTheSubqueryTableIsWritten` | base builder never swapped in | red |
| `JoinCacheInvalidationTest::testTheDefaultBaseQueryBuilderIsTheRecordingOne` | base builder never swapped in | red |
| `JoinCacheInvalidationTest::testDeferredJoinSubQueryCacheTagsContainTheSubqueryTableTag` | clone materialization removed | red |
| `JoinCacheInvalidationTest::testDeferredJoinSubQueryCacheIsInvalidatedWhenTheSubqueryTableIsWritten` | clone materialization removed | red |
| `JoinCacheInvalidationTest::testACustomBaseQueryBuilderIsNotReplaced` | base builder never swapped in | **green — by design** |
| `JoinCacheInvalidationTest::testACustomBaseQueryBuilderIsNotReplaced` | fail-closed guard removed, always swap | red |

`testKeysForValuesWithoutSeparatorsAreUnchanged` is green on `master` on purpose:
it asserts that ordinary values keep the bytes they already had, so passing before
the change is what it claims. Its discriminating mutation is the escape set —
adding `"%" => "%25"` to `KEY_SEPARATOR_ESCAPES` turns it red on the `50%` case.
That mutation was run and confirmed.

**There is deliberately no `ofMany()` test for the subquery-join recording.** An
`ofMany()` relation already tags the related model's own table through that
model, so its tags are `…book` and `…books` with or without any recording —
probed and confirmed both ways. A test for it would pass before the change as
readily as after, which is the exact failure this branch exists to close. The
deferred `beforeQuery` joinSub against an unrelated table is the case that
changes, and it is the one under test.

Four tests are green pre-fix on purpose, because each pins behaviour that must
*not* change. Each carries its own discriminating mutation instead, all run and
confirmed:

- `testACustomBaseQueryBuilderIsNotReplaced` — removing the guard, so the swap
  always happens, reddens it.

- `testKeysForValuesWithoutSeparatorsAreUnchanged` — adding a fourth pair to
  `KEY_SEPARATOR_ESCAPES` reddens it.
- `testPlainWhereKeyIsUnchanged` — deleting the `Basic` exemption from
  `getTypeClause()` reddens it.
- `testBinaryUuidWhereInValueIsNotEscaped` — moving the escaping *above* the
  binary-UUID branch reddens it, which is precisely the ordering it exists to
  hold.

`testSeparatorEncodingIsNotDoubleEncoded` earned its name the hard way. The first
mutation written for it — swapping `strtr()` for a `str_replace()` loop — left it
green, because that loop happened to encode `%` first. The hazard is the *order*
of the pairs, not the mechanism: a loop reaching `%` last turns `-` into `%252D`,
and that mutation does redden it. The comment at the constant was corrected to
state the property that was actually verified.

`testPlainWhereKeyIsUnchanged` is green pre-fix for the same reason: it exists to
pin the no-cold-cache constraint, so passing before the change is the claim. Its
discriminating mutation is the `Basic` exemption — deleting it from
`getTypeClause()` turns the test red. That mutation was run and confirmed.

A first draft of `testWhereTimeReturnsItsOwnResultsAfterWhereYearWasCached`
passed pre-fix. It compared `whereYear(2020)` against `whereTime('=', '13:45:00')`,
whose different bindings already separated the keys, so it proved nothing about
the type. It now binds `2020` on both sides, which is the pair that actually
collided.

`testHasManyThroughPaginationIsCached` covers a signature change rather than a
behaviour change, so it has no pre-fix baseline. It was mutation-checked against
the method it covers instead: rewriting the key differentiator inside
`CachesOneOrManyThrough::paginate()` turns it red, which proves it reaches the
changed method. That check also caught a first draft of this test that did not:
`BelongsToMany` does not use this trait, so `$book->stores()` never enters it.

## Known limitations, stated rather than hidden

- **A model that supplies its own base query builder gets no subquery-join
  recording.** That is the deliberate fail-closed side of not replacing it.
- **`joinSubWhere()` is not overridden** — no such method exists on
  `Illuminate\Database\Query\Builder` in Laravel 11, 12 or 13. `joinLateral()`
  and `leftJoinLateral()` are covered instead, being the same defect shape.
