### PR TITLE
fix: 🐛 count real bindings, not values entries, in whereIn/whereNotIn cache keys.

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -253,8 +253,10 @@ class CacheKey
         $placeholderCount = preg_match_all('/\?(?=(?:[^"]*"[^"]*")*[^"]*\Z)/m', $subquery);
 
         if ($placeholderCount === 0) {
-            if (data_get($where, "values")) {
-                $this->currentBinding += count(data_get($where, "values"));
+            $whereValues = data_get($where, "values", []);
+
+            if ($whereValues) {
+                $this->currentBinding += count($this->query->cleanBindings($whereValues));
             }
 
             $values = $this->recursiveImplode([$subquery], "_");

--- a/tests/Integration/CachedBuilder/WhereInTest.php
+++ b/tests/Integration/CachedBuilder/WhereInTest.php
@@ -5,6 +5,7 @@ use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedAuthor;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
 use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use Illuminate\Database\Query\Expression;
 
 class WhereInTest extends IntegrationTestCase
 {
@@ -221,5 +222,49 @@ class WhereInTest extends IntegrationTestCase
             ->get();
 
         $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+    }
+
+    public function testWhereInWithExpressionValueDoesNotCollideAcrossDifferentQueries()
+    {
+        $author = Author::factory()->create(["name" => "Alice", "email" => "shared@example.com"]);
+        Author::factory()->create(["name" => "Bob", "email" => "shared@example.com"]);
+
+        $resultsForAlice = (new Author)
+            ->whereIn("id", [$author->id, new Expression((string) $author->id)])
+            ->where("name", "Alice")
+            ->where("email", "shared@example.com")
+            ->get();
+        $resultsForBob = (new Author)
+            ->whereIn("id", [$author->id, new Expression((string) $author->id)])
+            ->where("name", "Bob")
+            ->where("email", "shared@example.com")
+            ->get();
+
+        $this->assertEquals(["Alice"], $resultsForAlice->pluck("name")->toArray());
+        $this->assertEquals([], $resultsForBob->pluck("name")->toArray());
+    }
+
+    public function testWhereNotInWithNoOpSubqueryDoesNotCollideAcrossDifferentQueries()
+    {
+        Author::factory()->create(["name" => "Alice", "email" => "shared@example.com"]);
+        Author::factory()->create(["name" => "Bob", "email" => "shared@example.com"]);
+
+        $noOpExclusion = function ($query) {
+            $query->select("id")->from("authors")->whereRaw("1 = 0");
+        };
+
+        $resultsForAlice = (new Author)
+            ->whereNotIn("id", $noOpExclusion)
+            ->where("name", "Alice")
+            ->where("email", "shared@example.com")
+            ->get();
+        $resultsForBob = (new Author)
+            ->whereNotIn("id", $noOpExclusion)
+            ->where("name", "Bob")
+            ->where("email", "shared@example.com")
+            ->get();
+
+        $this->assertEquals(["Alice"], $resultsForAlice->pluck("name")->toArray());
+        $this->assertEquals(["Bob"], $resultsForBob->pluck("name")->toArray());
     }
 }


### PR DESCRIPTION
Hey! While using this package on a bigger project, I ran into a caching bug and tracked it down.

`CacheKey::getInAndNotInClauses()` counts items in the whereIn/whereNotIn values array to figure out how many real bindings that clause used, then uses that count to know where to read the next where() clause's value from.

That count is wrong when an item doesn't actually produce a "?" in the SQL:
- `whereIn('id', fn ($q) => $q->select('x')->from('y'))` - Laravel turns this into one Expression item. If the subquery has no where() of its own, it needs 0 real bindings, but the count says 1.
- `whereIn('id', [1, DB::raw(2), 3])` - 3 items, but only 2 real bindings, since the raw one renders straight into the SQL.

Since that count moves a shared pointer through the query's bindings, getting it wrong shifts every where() clause after it. Worst case, two different queries end up building the identical cache key, and one gets served the other's cached result. Reproduced this directly,  two queries differing only in a later where('name', ...) value produced the same key.

Fix: count `$this->query->cleanBindings($whereValues)` instead of the raw array. `cleanBindings()` strips non-bindable values before counting - same thing whereIn()/whereNotIn() already use internally.

Added two tests reproducing the collision (one per case above). Both fail without the fix, pass with it. Full suite (467 tests) green.