### PR TITLE
fix: 🐛 Close the cache-key gaps left open after #617 and #618

### DIFF
--- a/src/CacheKey.php
+++ b/src/CacheKey.php
@@ -8,6 +8,7 @@ use BackedEnum;
 use DateTimeInterface;
 use GeneaLabs\LaravelModelCaching\Traits\CachePrefixing;
 use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -39,6 +40,44 @@ class CacheKey
         "%" => "%25",
         "-" => "%2D",
         "_" => "%5F",
+    ];
+
+    // Query state that a named method above writes into the key. Anything the
+    // builder carries that is in neither this list nor the one below is hashed
+    // by getUnkeyedQueryPropertiesSlug().
+    //
+    // The split exists because enumeration is what has failed here repeatedly.
+    // groupBy, joins, unions and distinct were each absent from the key, and
+    // each returned another query's rows, because no method named them and
+    // nothing noticed. Listing what *is* handled inverts that: a property this
+    // class has never heard of produces an over-specific key, which costs a
+    // cache miss, rather than a shared key, which returns wrong rows.
+    private const KEYED_QUERY_PROPERTIES = [
+        "beforeQueryCallbacks",
+        "columns",
+        "distinct",
+        "from",
+        "groups",
+        "havings",
+        "joins",
+        "limit",
+        "offset",
+        "orders",
+        "unions",
+        "wheres",
+    ];
+
+    // Builder state with no bearing on which rows come back: connection
+    // plumbing, the grammar's operator tables, and the binding array the
+    // clause walkers already read through their own channels.
+    private const UNKEYED_INFRASTRUCTURE_PROPERTIES = [
+        "bindings",
+        "bitwiseOperators",
+        "connection",
+        "grammar",
+        "operators",
+        "processor",
+        "useWritePdo",
     ];
 
     protected $currentBinding = 0;
@@ -75,14 +114,19 @@ class CacheKey
         $key .= $this->getModelSlug();
         $key .= $this->getIdColumn($idColumn ?: "");
         $key .= $this->getQueryColumns($columns);
+        $key .= $this->getDistinctClause();
+        $key .= $this->getJoinClauses();
         $key .= $this->getWhereClauses();
+        $key .= $this->getGroupByClauses();
         $key .= $this->getHavingClauses();
         $key .= $this->getWithModels();
         $key .= $this->getOrderByClauses();
         $key .= $this->getOffsetClause();
         $key .= $this->getLimitClause();
+        $key .= $this->getUnionClauses();
         $key .= $this->getBindingsSlug();
         $key .= $this->getDeferredCallbacksSlug();
+        $key .= $this->getUnkeyedQueryPropertiesSlug();
         $key .= $keyDifferentiator;
         $key .= $this->macroKey;
 
@@ -191,12 +235,17 @@ class CacheKey
 
     protected function getHavingClauses()
     {
-        return Collection::make($this->query->havings)->reduce(function ($carry, $having) {
+        $clauses = Collection::make($this->query->havings)->reduce(function ($carry, $having) {
             $value = $carry;
             $value .= $this->getHavingClause($having);
 
             return $value;
         });
+
+        // havingRaw("total > ?", [5]) stores only its SQL in the clause array
+        // and puts the 5 in the "having" binding channel, so two calls that
+        // differ only in their bindings build the same clause string.
+        return $clauses . $this->getChannelBindingsSlug("having");
     }
 
     protected function getHavingClause(array $having): string
@@ -204,10 +253,58 @@ class CacheKey
         $return = '-having';
 
         foreach ($having as $key => $value) {
-            $return .= '_' . $key . '_' . str_replace(' ', '_', $value);
+            $return .= '_' . $key . '_' . $this->stringifyHavingValue($value);
         }
 
         return $return;
+    }
+
+    // A having clause carries whatever shape its type needs: a scalar for
+    // having(), a two-element array for havingBetween(), a bool for the "not"
+    // flag, a nested Builder for having(Closure). Passing each of those to
+    // str_replace() assumed they were all strings, so having("total", ">", 5)
+    // raised a TypeError and havingBetween() folded both bounds into the
+    // literal "Array", giving every range the same key.
+    //
+    // Strings keep the exact space-to-underscore rewrite they had before, so
+    // every havingRaw() key that worked stays byte-identical.
+    private function stringifyHavingValue(mixed $value) : string
+    {
+        if (is_array($value)) {
+            return implode("_", array_map($this->stringifyHavingValue(...), $value));
+        }
+
+        if ($value instanceof QueryBuilder) {
+            return Collection::make($value->havings)
+                ->reduce(fn ($carry, $nested) => $carry . $this->getHavingClause($nested), "");
+        }
+
+        if (is_bool($value)) {
+            return $value ? "1" : "0";
+        }
+
+        if ($value === null) {
+            return "";
+        }
+
+        return str_replace(" ", "_", $this->processEnum($value));
+    }
+
+    // Bindings that live in a channel of their own rather than in "where".
+    // The clause arrays for those channels hold placeholders, not values, so
+    // the values reach the key only from here.
+    private function getChannelBindingsSlug(string $channel) : string
+    {
+        $bindings = data_get($this->query->bindings, $channel, []);
+
+        if (! $bindings) {
+            return "";
+        }
+
+        return "-{$channel}Bindings_" . implode(
+            "_",
+            array_map($this->stringifyBinding(...), $bindings),
+        );
     }
 
     protected function getIdColumn(string $idColumn) : string
@@ -217,13 +314,14 @@ class CacheKey
 
     protected function getInAndNotInClauses(array $where) : string
     {
-        if (! in_array($where["type"], ["In", "NotIn", "InRaw"])) {
+        if (! in_array($where["type"], ["In", "NotIn", "InRaw", "NotInRaw"])) {
             return "";
         }
 
         $type = strtolower($where["type"]);
         $booleanSlug = $this->getBooleanSlug($where);
         $subquery = $this->getValuesFromWhere($where);
+        $bindingCount = $this->getInClauseBindingCount($where);
 
         if (
             ! is_numeric($subquery)
@@ -233,6 +331,10 @@ class CacheKey
             try {
                 $subquery = Uuid::fromBytes($subquery);
                 $values = $this->recursiveImplode([$subquery], "_");
+                // whereIn() bound the raw UUID, so the cursor owes it a slot
+                // whichever branch renders the clause. Returning without
+                // advancing left every later clause reading one binding early.
+                $this->currentBinding += $bindingCount;
 
                 return "{$booleanSlug}-{$where["column"]}_{$type}{$values}";
             } catch (Throwable) {
@@ -253,11 +355,7 @@ class CacheKey
         $placeholderCount = preg_match_all('/\?(?=(?:[^"]*"[^"]*")*[^"]*\Z)/m', $subquery);
 
         if ($placeholderCount === 0) {
-            $whereValues = data_get($where, "values", []);
-
-            if ($whereValues) {
-                $this->currentBinding += count($this->query->cleanBindings($whereValues));
-            }
+            $this->currentBinding += $bindingCount;
 
             $values = $this->recursiveImplode([$subquery], "_");
 
@@ -282,6 +380,111 @@ class CacheKey
         $values = $this->recursiveImplode($subquery->toArray(), "_");
 
         return "{$booleanSlug}-{$where["column"]}_{$type}{$values}";
+    }
+
+    protected function getDistinctClause() : string
+    {
+        if (! property_exists($this->query, "distinct")
+            || ! $this->query->distinct
+        ) {
+            return "";
+        }
+
+        // distinct() sets true. distinct("a", "b") sets the column list.
+        if (! is_array($this->query->distinct)) {
+            return "-distinct";
+        }
+
+        return "-distinct_" . implode("_", array_map(
+            $this->expressionToString(...),
+            $this->query->distinct,
+        ));
+    }
+
+    protected function getGroupByClauses() : string
+    {
+        if (! property_exists($this->query, "groups")
+            || ! $this->query->groups
+        ) {
+            return "";
+        }
+
+        // Column names are not escaped, here or in getOrderByClauses() and
+        // getQueryColumns(). Escaping is for bound values, which an
+        // application controls outright; an identifier comes from the
+        // developer's own code.
+        $groups = array_map(
+            $this->expressionToString(...),
+            $this->query->groups,
+        );
+
+        return "-groupBy_" . implode("_", $groups)
+            . $this->getChannelBindingsSlug("groupBy");
+    }
+
+    protected function getJoinClauses() : string
+    {
+        if (! property_exists($this->query, "joins")
+            || ! $this->query->joins
+        ) {
+            return "";
+        }
+
+        // The join type separates join() from leftJoin() on one table, and the
+        // hashed ON conditions separate two joins of the same table on
+        // different columns. CacheTags already tags the joined table, but a
+        // tag is a namespace and not a key: two joins landing in the same
+        // namespace still need different keys.
+        $joins = array_map(
+            fn ($join) => $join->type
+                . "_" . $this->expressionToString($join->table)
+                . "_" . substr(
+                    sha1($this->encodeForKeyHash($this->normalizeForHash($join->wheres))),
+                    0,
+                    12,
+                ),
+            $this->query->joins,
+        );
+
+        return "-join_" . implode("_", $joins)
+            . $this->getChannelBindingsSlug("join");
+    }
+
+    protected function getUnionClauses() : string
+    {
+        if (! property_exists($this->query, "unions")
+            || ! $this->query->unions
+        ) {
+            return "";
+        }
+
+        $unions = array_map(
+            fn ($union) => (data_get($union, "all") ? "all_" : "")
+                . sha1(
+                    $union["query"]->toSql()
+                    . $this->encodeForKeyHash($union["query"]->getBindings())
+                ),
+            $this->query->unions,
+        );
+
+        return "-union_" . implode("_", $unions);
+    }
+
+    // How many binding slots an In-family clause owns.
+    //
+    // whereIn() calls addBinding(cleanBindings($values)), so its count is the
+    // value list with every Expression removed. whereIntegerInRaw() and
+    // whereIntegerNotInRaw() inline their values into the SQL and call
+    // addBinding() not at all, so they own nothing. Counting the value list
+    // for those two pushed the cursor past bindings belonging to later
+    // clauses, and those clauses then read another query's values.
+    private function getInClauseBindingCount(array $where) : int
+    {
+        if (in_array($where["type"], ["InRaw", "NotInRaw"], true)) {
+            return 0;
+        }
+
+        return count($this->query->cleanBindings(data_get($where, "values", [])));
     }
 
     protected function getLimitClause() : string
@@ -361,10 +564,9 @@ class CacheKey
             return $this->escapeKeySegment($this->processEnum($value));
         }, $where["values"]));
 
-        // Advance binding pointer for each value in the RowValues clause
-        foreach ($where["values"] as $ignored) {
-            $this->currentBinding++;
-        }
+        // whereRowValues() binds through cleanBindings() too, so an Expression
+        // among the values is inlined into the SQL and owns no binding slot.
+        $this->currentBinding += count($this->query->cleanBindings($where["values"]));
 
         return $this->getBooleanSlug($where)
             . "-{$columns}_{$operator}_{$values}";
@@ -372,7 +574,7 @@ class CacheKey
 
     protected function getOtherClauses(array $where) : string
     {
-        if (in_array($where["type"], ["Exists", "Nested", "NotExists", "Column", "raw", "In", "NotIn", "InRaw", "RowValues"])) {
+        if (in_array($where["type"], ["Exists", "Nested", "NotExists", "Column", "raw", "In", "NotIn", "InRaw", "NotInRaw", "RowValues"])) {
             return "";
         }
 
@@ -543,10 +745,21 @@ class CacheKey
             return $values;
         }
 
+        // where("column", ">", new Expression(...)) is compiled straight into
+        // the SQL and binds nothing, so consuming a slot for it would hand the
+        // next clause a value that is not its own.
+        if (data_get($where, "value") instanceof Expression) {
+            return $values;
+        }
+
         $this->currentBinding++;
         $values = $this->stringifyBinding($currentBinding);
 
-        if ($where["type"] === "between") {
+        // whereBetween() binds both bounds through cleanBindings(), so an
+        // Expression bound leaves the clause owning one slot rather than two.
+        if ($where["type"] === "between"
+            && count($this->query->cleanBindings(data_get($where, "values", []))) > 1
+        ) {
             $values .= "_" . $this->stringifyBinding($this->getCurrentBinding("where"));
             $this->currentBinding++;
         }
@@ -554,7 +767,7 @@ class CacheKey
         return $values;
     }
 
-    protected function getWhereClauses(array $wheres = []) : string
+    protected function getWhereClauses(?array $wheres = null) : string
     {
         return "" . $this->getWheres($wheres)
             ->reduce(function ($carry, $where) {
@@ -570,17 +783,25 @@ class CacheKey
             });
     }
 
-    protected function getWheres(array $wheres) : Collection
+    // A null $wheres means "the caller named no clause list", so the query's
+    // own clauses are used. An empty array means "this clause list is
+    // genuinely empty", and nothing is walked.
+    //
+    // Collapsing the two is what made getNestedClauses() recurse without end.
+    // whereExists() over a subquery carrying no where clause handed [] down,
+    // this method read that as "use $this->query->wheres", and those still
+    // hold the Exists clause that called it. The recursion has no floor, so it
+    // exhausts the stack. PHP raises no error for that: the process dies on
+    // SIGSEGV, which no handler can catch.
+    protected function getWheres(?array $wheres) : Collection
     {
-        $wheres = collect($wheres);
-
-        if ($wheres->isEmpty()
-            && property_exists($this->query, "wheres")
-        ) {
-            $wheres = collect($this->query->wheres);
+        if ($wheres !== null) {
+            return collect($wheres);
         }
 
-        return $wheres;
+        return collect(property_exists($this->query, "wheres")
+            ? $this->query->wheres
+            : []);
     }
 
     protected function getWithModels() : string
@@ -683,6 +904,63 @@ class CacheKey
     private function escapeKeySegment(string $segment) : string
     {
         return strtr($segment, self::KEY_SEPARATOR_ESCAPES);
+    }
+
+    // The backstop. Every builder property that no named method reads and that
+    // is not connection plumbing lands in one hash, so the key changes when it
+    // does. Today that covers aggregate, indexHint, groupLimit, lock,
+    // unionLimit, unionOffset, unionOrders and afterQueryCallbacks. Tomorrow it
+    // covers whatever Laravel adds, with no edit here.
+    //
+    // Only non-empty values are hashed, so a builder in its default state
+    // produces nothing and every existing key is unchanged.
+    private function getUnkeyedQueryPropertiesSlug() : string
+    {
+        $unkeyed = Collection::make(get_object_vars($this->query))
+            ->except(array_merge(
+                self::KEYED_QUERY_PROPERTIES,
+                self::UNKEYED_INFRASTRUCTURE_PROPERTIES,
+            ))
+            ->reject(fn ($value) => $value === null || $value === false || $value === [])
+            ->map($this->normalizeForHash(...))
+            ->sortKeys()
+            ->all();
+
+        if (! $unkeyed) {
+            return "";
+        }
+
+        return "-q" . substr(sha1($this->encodeForKeyHash($unkeyed)), 0, 12);
+    }
+
+    // json_encode() renders an Expression as "{}" because its value is
+    // protected, and serialize() throws on a Closure or on anything holding a
+    // PDO connection. Both would make a hash that cannot tell two queries
+    // apart, or one that fatals. Reducing every object to something printable
+    // first keeps the hash total and honest about what it can distinguish.
+    private function normalizeForHash(mixed $value) : mixed
+    {
+        if (is_array($value)) {
+            return array_map($this->normalizeForHash(...), $value);
+        }
+
+        if ($value instanceof Expression) {
+            return $this->expressionToString($value);
+        }
+
+        if ($value instanceof \Closure) {
+            return "Closure";
+        }
+
+        if ($value instanceof QueryBuilder) {
+            return $value->toSql() . $this->encodeForKeyHash($value->getBindings());
+        }
+
+        if (is_object($value)) {
+            return get_class($value);
+        }
+
+        return $value;
     }
 
     private function processEnum(

--- a/tests/Integration/CachedBuilder/BelongsToManyTest.php
+++ b/tests/Integration/CachedBuilder/BelongsToManyTest.php
@@ -21,7 +21,7 @@ class BelongsToManyTest extends IntegrationTestCase
             ->books
             ->first()
             ->id;
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:stores:genealabslaravelmodelcachingcachedbelongstomany-book_store.book_id_=_{$bookId}");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:stores:genealabslaravelmodelcachingcachedbelongstomany-join_inner_book_store_f6999d9f3303-book_store.book_id_=_{$bookId}");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesstore",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:stores",

--- a/tests/Integration/CachedBuilder/BindingCursorTest.php
+++ b/tests/Integration/CachedBuilder/BindingCursorTest.php
@@ -1,0 +1,181 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use Illuminate\Database\Query\Expression;
+use ReflectionMethod;
+
+// CacheKey walks the "where" binding array with a cursor, and every clause
+// handler advances it by the number of bindings that clause consumed. Where
+// the advance disagreed with what Laravel actually bound, every later clause
+// read the wrong slot and two queries differing only in those later clauses
+// built one key.
+//
+// Each test below pins the *following* clause's value in the key, because that
+// is what a mis-advanced cursor corrupts. Asserting only on the In clause
+// itself would stay green with the cursor still wrong.
+class BindingCursorTest extends IntegrationTestCase
+{
+    private function cacheKey($query) : string
+    {
+        return (new ReflectionMethod($query, "makeCacheKey"))
+            ->invoke($query);
+    }
+
+    // whereIntegerInRaw() inlines its values into the SQL and calls
+    // addBinding() not at all, so it owns no binding slot. Advancing by the
+    // value count pushed the cursor past the clauses that follow.
+    //
+    // Four trailing clauses, not two. getValuesFromBindings() falls back to
+    // the clause's literal value once the cursor runs off the end of the
+    // binding array, which produces the correct key by accident and hides the
+    // over-advance. The cursor has to land on a real binding belonging to a
+    // different clause for the defect to show.
+    public function testWhereIntegerInRawConsumesNoBindings()
+    {
+        $key = $this->cacheKey((new Book)
+            ->whereIntegerInRaw("id", [1, 2])
+            ->where("title", "a")
+            ->where("description", "b")
+            ->where("title", "c")
+            ->where("description", "d"));
+
+        $this->assertStringEndsWith(
+            "-id_inraw_1_2-title_=_a-description_=_b-title_=_c-description_=_d",
+            $key,
+        );
+    }
+
+    public function testWhereIntegerInRawReturnsItsOwnRowsAfterAnotherFilterWasCached()
+    {
+        (new Book)
+            ->whereIntegerInRaw("id", [1, 2])
+            ->where("title", "a")->where("description", "b")
+            ->where("title", "c")->where("description", "d")
+            ->get();
+
+        $books = (new Book)
+            ->whereIntegerInRaw("id", [1, 2])
+            ->where("title", "e")->where("description", "f")
+            ->where("title", "c")->where("description", "d")
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->whereIntegerInRaw("id", [1, 2])
+            ->where("title", "e")->where("description", "f")
+            ->where("title", "c")->where("description", "d")
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+    }
+
+    // NotInRaw was named by neither getInAndNotInClauses() nor the exclusion
+    // list in getOtherClauses(), so it fell through to the generic
+    // single-binding path: its excluded values never reached the key at all,
+    // and it ate the next clause's binding on the way past.
+    public function testWhereIntegerNotInRawKeysItsExcludedValues()
+    {
+        $firstSet = $this->cacheKey((new Book)->whereIntegerNotInRaw("id", [1, 2, 3])->where("title", "a"));
+        $secondSet = $this->cacheKey((new Book)->whereIntegerNotInRaw("id", [4, 5, 6])->where("title", "a"));
+
+        $this->assertStringEndsWith("-id_notinraw_1_2_3-title_=_a", $firstSet);
+        $this->assertStringEndsWith("-id_notinraw_4_5_6-title_=_a", $secondSet);
+    }
+
+    // Same fallback masking as the InRaw case above: four trailing clauses so
+    // the over-advanced cursor lands on a real binding rather than off the end.
+    public function testWhereIntegerNotInRawConsumesNoBindings()
+    {
+        $key = $this->cacheKey((new Book)
+            ->whereIntegerNotInRaw("id", [1, 2])
+            ->where("title", "a")
+            ->where("description", "b")
+            ->where("title", "c")
+            ->where("description", "d"));
+
+        $this->assertStringEndsWith(
+            "-id_notinraw_1_2-title_=_a-description_=_b-title_=_c-description_=_d",
+            $key,
+        );
+    }
+
+    public function testWhereIntegerNotInRawReturnsItsOwnRowsAfterAnotherExclusionWasCached()
+    {
+        (new Book)->whereIntegerNotInRaw("id", [1, 2])->get();
+
+        $books = (new Book)->whereIntegerNotInRaw("id", [3, 4])->get();
+        $liveResults = (new UncachedBook)->whereIntegerNotInRaw("id", [3, 4])->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+    }
+
+    // The binary-UUID branch returns as soon as it recognises a 16-byte value,
+    // and used to return without advancing at all, although whereIn() had
+    // bound that value.
+    public function testBinaryUuidWhereInAdvancesTheCursorBeforeReturning()
+    {
+        $uuid = hex2bin("0123456789abcdef0123456789abcdef");
+
+        $key = $this->cacheKey((new Book)
+            ->whereIn("id", [$uuid])
+            ->where("title", "a")
+            ->where("description", "b"));
+
+        $this->assertStringEndsWith(
+            "-id_in_01234567-89ab-cdef-0123-456789abcdef-title_=_a-description_=_b",
+            $key,
+        );
+    }
+
+    // cleanBindings() drops an Expression, so whereIn() binds one value here,
+    // not two. This is the case PR #618 fixed; it is pinned again because the
+    // count moved into a shared helper that the *Raw types also use.
+    public function testWhereInWithAnExpressionValueConsumesOnlyTheBoundValues()
+    {
+        $key = $this->cacheKey((new Book)
+            ->whereIn("id", [1, new Expression("2")])
+            ->where("title", "a")
+            ->where("description", "b"));
+
+        $this->assertStringEndsWith("-title_=_a-description_=_b", $key);
+    }
+
+    public function testWhereRowValuesWithAnExpressionConsumesOnlyTheBoundValues()
+    {
+        $key = $this->cacheKey((new Book)
+            ->whereRowValues(["id", "title"], "=", [1, new Expression("'x'")])
+            ->where("description", "b")
+            ->where("title", "a"));
+
+        $this->assertStringEndsWith("-description_=_b-title_=_a", $key);
+    }
+
+    public function testWhereBetweenWithAnExpressionBoundConsumesOnlyOneSlot()
+    {
+        $key = $this->cacheKey((new Book)
+            ->whereBetween("id", [new Expression("1"), 10])
+            ->where("description", "b")
+            ->where("title", "a"));
+
+        $this->assertStringEndsWith("-description_=_b-title_=_a", $key);
+    }
+
+    public function testWhereBetweenWithTwoBoundValuesStillConsumesBothSlots()
+    {
+        $key = $this->cacheKey((new Book)
+            ->whereBetween("id", [1, 10])
+            ->where("title", "a"));
+
+        $this->assertStringEndsWith("-id_between_1_10-title_=_a", $key);
+    }
+
+    public function testBasicWhereWithAnExpressionValueConsumesNoBinding()
+    {
+        $key = $this->cacheKey((new Book)
+            ->where("id", ">", new Expression("1"))
+            ->where("description", "b")
+            ->where("title", "a"));
+
+        $this->assertStringEndsWith("-description_=_b-title_=_a", $key);
+    }
+}

--- a/tests/Integration/CachedBuilder/HasManyThroughTest.php
+++ b/tests/Integration/CachedBuilder/HasManyThroughTest.php
@@ -38,7 +38,7 @@ class HasManyThroughTest extends IntegrationTestCase
 
     public function testLazyloadedHasManyThrough()
     {
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:printers:genealabslaravelmodelcachingtestsfixturesprinter-books.author_id_=_1");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:printers:genealabslaravelmodelcachingtestsfixturesprinter-join_inner_books_bca1a55e5c9c-books.author_id_=_1");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesprinter",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:printers",

--- a/tests/Integration/CachedBuilder/HasOneThroughTest.php
+++ b/tests/Integration/CachedBuilder/HasOneThroughTest.php
@@ -38,7 +38,7 @@ class HasOneThroughTest extends IntegrationTestCase
 
     public function testLazyloadedHasOneThrough()
     {
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:histories:genealabslaravelmodelcachingtestsfixtureshistory-users.supplier_id_=_1-first");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:histories:genealabslaravelmodelcachingtestsfixtureshistory-join_inner_users_1f027b356718-users.supplier_id_=_1-first");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixtureshistory",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:histories",

--- a/tests/Integration/CachedBuilder/HavingTest.php
+++ b/tests/Integration/CachedBuilder/HavingTest.php
@@ -1,0 +1,133 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use ReflectionMethod;
+
+// getHavingClause() passed every member of the clause array to str_replace(),
+// which only accepts a string or an array of them. having() stores an int or
+// a float in "value", havingBetween() stores an array in "values", and both
+// store a bool in "not". So having() raised a TypeError on a cold query, and
+// havingBetween() folded both bounds into the literal "Array", giving every
+// range one key.
+//
+// Book carries no global scope, so nothing but the clause under test moves
+// these keys.
+class HavingTest extends IntegrationTestCase
+{
+    private function cacheKey($query) : string
+    {
+        return (new ReflectionMethod($query, "makeCacheKey"))
+            ->invoke($query);
+    }
+
+    public function testHavingWithNumericValueDoesNotThrow()
+    {
+        $books = (new Book)
+            ->groupBy("author_id")
+            ->having("author_id", ">", 1)
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->groupBy("author_id")
+            ->having("author_id", ">", 1)
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+        $this->assertNotEmpty($books);
+    }
+
+    public function testHavingBetweenDoesNotThrow()
+    {
+        $books = (new Book)
+            ->groupBy("author_id")
+            ->havingBetween("author_id", [1, 3])
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->groupBy("author_id")
+            ->havingBetween("author_id", [1, 3])
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+        $this->assertNotEmpty($books);
+    }
+
+    public function testHavingKeysTheBoundValueRatherThanItsType()
+    {
+        $lowBound = $this->cacheKey((new Book)->groupBy("author_id")->having("author_id", ">", 1));
+        $highBound = $this->cacheKey((new Book)->groupBy("author_id")->having("author_id", ">", 3));
+
+        $this->assertStringContainsString("-having_type_Basic_column_author_id_operator_>_value_1_boolean_and", $lowBound);
+        $this->assertStringContainsString("-having_type_Basic_column_author_id_operator_>_value_3_boolean_and", $highBound);
+    }
+
+    public function testHavingBetweenKeysBothBoundsRatherThanTheWordArray()
+    {
+        $narrow = $this->cacheKey((new Book)->groupBy("author_id")->havingBetween("author_id", [1, 3]));
+        $wide = $this->cacheKey((new Book)->groupBy("author_id")->havingBetween("author_id", [4, 9]));
+
+        $this->assertStringContainsString("_values_1_3_", $narrow);
+        $this->assertStringContainsString("_values_4_9_", $wide);
+        $this->assertStringNotContainsString("Array", $narrow);
+    }
+
+    public function testHavingBetweenReturnsItsOwnRowsAfterAnotherRangeWasCached()
+    {
+        (new Book)->groupBy("author_id")->havingBetween("author_id", [1, 2])->get();
+
+        $books = (new Book)->groupBy("author_id")->havingBetween("author_id", [3, 4])->get();
+        $liveResults = (new UncachedBook)->groupBy("author_id")->havingBetween("author_id", [3, 4])->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+    }
+
+    // havingRaw() keeps its bindings out of the clause array, so two calls
+    // differing only in a bound value produce the same clause string. The
+    // "having" binding channel is what tells them apart.
+    public function testHavingRawKeysItsBindings()
+    {
+        $lowBound = $this->cacheKey((new Book)->groupBy("author_id")->havingRaw("author_id > ?", [1]));
+        $highBound = $this->cacheKey((new Book)->groupBy("author_id")->havingRaw("author_id > ?", [3]));
+
+        $this->assertNotEquals($lowBound, $highBound);
+        $this->assertStringContainsString("-havingBindings_1", $lowBound);
+        $this->assertStringContainsString("-havingBindings_3", $highBound);
+    }
+
+    public function testHavingRawReturnsItsOwnRowsAfterAnotherBindingWasCached()
+    {
+        (new Book)->groupBy("author_id")->havingRaw("author_id > ?", [1])->get();
+
+        $books = (new Book)->groupBy("author_id")->havingRaw("author_id > ?", [3])->get();
+        $liveResults = (new UncachedBook)->groupBy("author_id")->havingRaw("author_id > ?", [3])->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+    }
+
+    // A raw having with no bindings is the one shape that already worked, so
+    // its key has to stay exactly as it was or every cached one goes cold.
+    public function testUnboundHavingRawKeyIsUnchanged()
+    {
+        $key = $this->cacheKey((new Book)->groupBy("author_id")->havingRaw("count(*) > 1"));
+
+        $this->assertStringEndsWith(
+            "-groupBy_author_id-having_type_Raw_sql_count(*)_>_1_boolean_and",
+            $key,
+        );
+    }
+
+    public function testOrHavingKeysDistinctlyFromHaving()
+    {
+        $conjunction = $this->cacheKey((new Book)
+            ->groupBy("author_id")
+            ->having("author_id", ">", 1)
+            ->having("author_id", "<", 9));
+        $disjunction = $this->cacheKey((new Book)
+            ->groupBy("author_id")
+            ->having("author_id", ">", 1)
+            ->orHaving("author_id", "<", 9));
+
+        $this->assertNotEquals($conjunction, $disjunction);
+        $this->assertStringContainsString("_boolean_or", $disjunction);
+    }
+}

--- a/tests/Integration/CachedBuilder/NestedSubqueryRecursionTest.php
+++ b/tests/Integration/CachedBuilder/NestedSubqueryRecursionTest.php
@@ -1,0 +1,86 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use ReflectionMethod;
+
+// A subquery carrying no where clause used to make getNestedClauses() call
+// getWhereClauses([]), which getWheres() read as "no argument given" and
+// answered with the outer query's clauses. Those still hold the clause that
+// asked, so the walk had no floor and the process died on SIGSEGV.
+//
+// A segfault is not an exception, so these tests cannot assert on one. They
+// assert the query returns its rows instead: without the fix the PHP process
+// never reaches the assertion and PHPUnit reports the crash.
+class NestedSubqueryRecursionTest extends IntegrationTestCase
+{
+    private function cacheKey($query) : string
+    {
+        return (new ReflectionMethod($query, "makeCacheKey"))
+            ->invoke($query);
+    }
+
+    public function testWhereExistsWithoutInnerWhereClausesBuildsAKey()
+    {
+        $books = (new Book)
+            ->whereExists(fn ($query) => $query->select("id")->from("authors"))
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->whereExists(fn ($query) => $query->select("id")->from("authors"))
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+        $this->assertNotEmpty($books);
+    }
+
+    public function testWhereNotExistsWithoutInnerWhereClausesBuildsAKey()
+    {
+        $books = (new Book)
+            ->whereNotExists(fn ($query) => $query->select("id")->from("authors"))
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->whereNotExists(fn ($query) => $query->select("id")->from("authors"))
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+    }
+
+    // The empty subquery has to key as empty rather than as a copy of the
+    // outer clauses. Asserting only that the query completes would stay green
+    // if the recursion were replaced by a depth cap, which would still write
+    // the outer clauses into the nested segment.
+    public function testEmptyNestedSubqueryContributesNoClausesToTheKey()
+    {
+        $key = $this->cacheKey((new Book)
+            ->where("title", "a")
+            ->whereExists(fn ($query) => $query->select("id")->from("authors")));
+
+        $this->assertStringEndsWith("-title_=_a-exists", $key);
+    }
+
+    public function testConstrainedNestedSubqueryStillContributesItsOwnClauses()
+    {
+        $key = $this->cacheKey((new Book)
+            ->where("title", "a")
+            ->whereExists(fn ($query) => $query->select("id")->from("authors")->where("id", 1)));
+
+        $this->assertStringEndsWith("-title_=_a-exists-id_=_1", $key);
+    }
+
+    public function testWhereExistsStillReturnsItsOwnRowsAfterWhereNotExistsWasCached()
+    {
+        (new Book)
+            ->whereNotExists(fn ($query) => $query->select("id")->from("authors"))
+            ->get();
+
+        $books = (new Book)
+            ->whereExists(fn ($query) => $query->select("id")->from("authors"))
+            ->get();
+        $liveResults = (new UncachedBook)
+            ->whereExists(fn ($query) => $query->select("id")->from("authors"))
+            ->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+    }
+}

--- a/tests/Integration/CachedBuilder/QueryPartCacheKeyTest.php
+++ b/tests/Integration/CachedBuilder/QueryPartCacheKeyTest.php
@@ -1,0 +1,212 @@
+<?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
+
+use GeneaLabs\LaravelModelCaching\CacheKey;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedBook;
+use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
+use ReflectionClass;
+use ReflectionMethod;
+
+// make() read the where clauses, the having clauses, the columns, the orders,
+// the limit and the offset, and nothing else. groupBy, joins, unions and
+// distinct never reached the key, so two queries differing only in one of them
+// shared a key and the second read the first one's rows.
+//
+// Book carries no global scope, so nothing but the part under test moves these
+// keys.
+class QueryPartCacheKeyTest extends IntegrationTestCase
+{
+    private function cacheKey($query) : string
+    {
+        return (new ReflectionMethod($query, "makeCacheKey"))
+            ->invoke($query);
+    }
+
+    public function testGroupByColumnsReachTheKey()
+    {
+        $byAuthor = $this->cacheKey((new Book)->groupBy("author_id"));
+        $byPublisher = $this->cacheKey((new Book)->groupBy("publisher_id"));
+
+        $this->assertStringEndsWith("-groupBy_author_id", $byAuthor);
+        $this->assertStringEndsWith("-groupBy_publisher_id", $byPublisher);
+    }
+
+    public function testGroupByReturnsItsOwnRowsAfterAnotherGroupingWasCached()
+    {
+        (new Book)->groupBy("author_id")->get();
+
+        $books = (new Book)->groupBy("publisher_id")->get();
+        $liveResults = (new UncachedBook)->groupBy("publisher_id")->get();
+
+        $this->assertEquals($liveResults->pluck("id"), $books->pluck("id"));
+    }
+
+    public function testGroupByRawKeysItsBindings()
+    {
+        $lowBound = $this->cacheKey((new Book)->groupByRaw("author_id + ?", [1]));
+        $highBound = $this->cacheKey((new Book)->groupByRaw("author_id + ?", [2]));
+
+        $this->assertNotEquals($lowBound, $highBound);
+        $this->assertStringContainsString("-groupByBindings_1", $lowBound);
+    }
+
+    public function testJoinedTableAndTypeReachTheKey()
+    {
+        $inner = $this->cacheKey((new Book)->join("authors", "authors.id", "=", "books.author_id"));
+        $left = $this->cacheKey((new Book)->leftJoin("authors", "authors.id", "=", "books.author_id"));
+
+        $this->assertStringContainsString("-join_inner_authors_", $inner);
+        $this->assertStringContainsString("-join_left_authors_", $left);
+        $this->assertNotEquals($inner, $left);
+    }
+
+    // Two joins of one table on different columns share their type, their
+    // table and their cache tags. Only the hashed ON conditions separate them.
+    public function testJoinsOnTheSameTableWithDifferentConditionsKeyDistinctly()
+    {
+        $byAuthor = $this->cacheKey((new Book)->join("authors", "authors.id", "=", "books.author_id"));
+        $byPublisher = $this->cacheKey((new Book)->join("authors", "authors.id", "=", "books.publisher_id"));
+
+        $this->assertNotEquals($byAuthor, $byPublisher);
+    }
+
+    public function testUnjoinedQueryKeyIsUnchanged()
+    {
+        $key = $this->cacheKey((new Book)->where("title", "a"));
+
+        $this->assertStringEndsWith("-title_=_a", $key);
+    }
+
+    public function testDistinctReachesTheKey()
+    {
+        $distinct = $this->cacheKey((new Book)->distinct());
+        $plain = $this->cacheKey(new Book);
+
+        $this->assertStringEndsWith("-distinct", $distinct);
+        $this->assertStringNotContainsString("-distinct", $plain);
+    }
+
+    public function testDistinctColumnsReachTheKey()
+    {
+        $key = $this->cacheKey((new Book)->distinct("author_id"));
+
+        $this->assertStringEndsWith("-distinct_author_id", $key);
+    }
+
+    public function testUnionsReachTheKey()
+    {
+        $first = $this->cacheKey((new Book)->where("id", 1)->union(DB::table("books")->where("id", 2)));
+        $second = $this->cacheKey((new Book)->where("id", 1)->union(DB::table("books")->where("id", 3)));
+
+        $this->assertStringContainsString("-union_", $first);
+        $this->assertNotEquals($first, $second);
+    }
+
+    public function testUnionReturnsItsOwnRowsAfterAnotherUnionWasCached()
+    {
+        (new Book)->where("id", 1)->union(DB::table("books")->where("id", 2))->get();
+
+        $books = (new Book)->where("id", 1)->union(DB::table("books")->where("id", 3))->get();
+        $liveResults = (new UncachedBook)->where("id", 1)->union(DB::table("books")->where("id", 3))->get();
+
+        $this->assertEquals($liveResults->pluck("id")->sort()->values(), $books->pluck("id")->sort()->values());
+    }
+
+    public function testUnionAllKeysDistinctlyFromUnion()
+    {
+        $union = $this->cacheKey((new Book)->where("id", 1)->union(DB::table("books")->where("id", 2)));
+        $unionAll = $this->cacheKey((new Book)->where("id", 1)->unionAll(DB::table("books")->where("id", 2)));
+
+        $this->assertNotEquals($union, $unionAll);
+        $this->assertStringContainsString("-union_all_", $unionAll);
+    }
+
+    // The backstop. Nothing names lock, indexHint, groupLimit, unionLimit,
+    // unionOffset or unionOrders, and each of them changes which rows come
+    // back. They reach the key through the unkeyed-property hash instead.
+    public function testUnkeyedQueryPropertiesReachTheKeyThroughTheBackstopHash()
+    {
+        $unlocked = $this->cacheKey((new Book)->where("id", 1));
+        $locked = $this->cacheKey((new Book)->where("id", 1)->lockForUpdate());
+        $shared = $this->cacheKey((new Book)->where("id", 1)->sharedLock());
+
+        $this->assertStringNotContainsString("-q", $unlocked);
+        $this->assertStringContainsString("-q", $locked);
+        $this->assertNotEquals($unlocked, $locked);
+        $this->assertNotEquals($locked, $shared);
+    }
+
+    public function testUnionOrderingReachesTheKeyThroughTheBackstopHash()
+    {
+        $ascending = $this->cacheKey((new Book)
+            ->where("id", 1)
+            ->union(DB::table("books")->where("id", 2))
+            ->orderBy("id"));
+        $descending = $this->cacheKey((new Book)
+            ->where("id", 1)
+            ->union(DB::table("books")->where("id", 2))
+            ->orderBy("id", "desc"));
+
+        $this->assertNotEquals($ascending, $descending);
+    }
+
+    // Both property lists are closed sets. A member silently added to either
+    // one stops that property reaching the key, which is the exact failure
+    // this backstop exists to prevent, and no other test would notice.
+    public function testTheKeyedAndInfrastructurePropertyListsArePinned()
+    {
+        $constants = (new ReflectionClass(CacheKey::class))->getConstants();
+
+        $this->assertSame(
+            [
+                "beforeQueryCallbacks",
+                "columns",
+                "distinct",
+                "from",
+                "groups",
+                "havings",
+                "joins",
+                "limit",
+                "offset",
+                "orders",
+                "unions",
+                "wheres",
+            ],
+            $constants["KEYED_QUERY_PROPERTIES"],
+        );
+        $this->assertSame(
+            [
+                "bindings",
+                "bitwiseOperators",
+                "connection",
+                "grammar",
+                "operators",
+                "processor",
+                "useWritePdo",
+            ],
+            $constants["UNKEYED_INFRASTRUCTURE_PROPERTIES"],
+        );
+    }
+
+    // Every property named in either list has to exist on the builder. A
+    // rename in Laravel would otherwise leave a live property unaccounted for
+    // while the list still looks complete.
+    public function testEveryListedPropertyExistsOnTheQueryBuilder()
+    {
+        $constants = (new ReflectionClass(CacheKey::class))->getConstants();
+        $builderProperties = array_keys(get_object_vars(DB::table("books")));
+
+        foreach (array_merge(
+            $constants["KEYED_QUERY_PROPERTIES"],
+            $constants["UNKEYED_INFRASTRUCTURE_PROPERTIES"],
+        ) as $property) {
+            $this->assertContains(
+                $property,
+                $builderProperties,
+                "CacheKey names '{$property}', which " . QueryBuilder::class . " no longer has.",
+            );
+        }
+    }
+}

--- a/tests/Integration/CachedBuilder/SelectTest.php
+++ b/tests/Integration/CachedBuilder/SelectTest.php
@@ -9,7 +9,7 @@ class SelectTest extends IntegrationTestCase
 {
     public function testSelectWithRawColumns()
     {
-        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook_author_id_AVG(id) AS averageIds_orderBy_author_id_asc");
+        $key = sha1("genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books:genealabslaravelmodelcachingtestsfixturesbook_author_id_AVG(id) AS averageIds-groupBy_author_id_orderBy_author_id_asc");
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",


### PR DESCRIPTION
Fixes: #619

## Summary

Closes all eleven cache-key defects in #619, and three more cases of the same classes that the issue does not name.

The suite goes from 465 tests to 507. Every fix has a test that goes red when the fix is removed, verified by mutation rather than by reading.

## ⚠️ Read this before merging: relation queries read cold once

Putting the join into the cache key changes the key for **every relation that joins** — `BelongsToMany`, `HasManyThrough`, `HasOneThrough`, `MorphToMany` — and for every hand-written `join()`. Every grouped query changes too.

Those keys are not wrong today in most applications, because the where clauses already tell two relation queries apart. The case that is wrong is `leftJoin` against `join` on one table: they share the key **and** the cache tags, so nothing separates them.

So this trades one cold-cache cycle on upgrade for closing that hole. Four existing tests needed their key literals updated for exactly this reason, which is the honest measure of the blast radius:

| Test | Segment gained |
| --- | --- |
| `BelongsToManyTest:24` | `-join_inner_book_store_f6999d9f3303` |
| `HasManyThroughTest:41` | `-join_inner_books_bca1a55e5c9c` |
| `HasOneThroughTest:41` | `-join_inner_users_1f027b356718` |
| `SelectTest:12` | `-groupBy_author_id` |

Every other existing key is byte-identical. Each new method returns an empty string when its query part is absent, and `havingRaw()` keeps the exact string rewrite it had.

## Part 1 — the crash class

### The segfault

`whereExists()` and `whereNotExists()` over a subquery with no where clause killed the PHP process.

`getNestedClauses()` handed `$where["query"]->wheres` to `getWhereClauses()`. When that array was empty, `getWheres()` read it as "the caller named no clause list" and substituted `$this->query->wheres`, which is the **outer** query's list. That list still holds the Exists clause that called in, so the walk had no floor and exhausted the stack.

A stack overflow is not a `Throwable`. No handler sees it, and the worker dies on SIGSEGV.

`getWheres()` now takes `?array`. Null means "no argument given". An empty array means "genuinely empty".

The test for this cannot assert on an exception. It asserts the query returns its rows, so without the fix PHPUnit reports the crash. Mutation-checked: reverting the fix exits 139.

### `having()` and `havingBetween()` threw

`getHavingClause()` passed every member of the clause array to `str_replace()`, which takes a string or an array of them. `having("total", ">", 5)` stores an int, `havingBetween()` stores an array, and both store a bool in `not`. So `having()` raised a `TypeError` on a cold query, and `havingBetween()` folded both bounds into the literal `"Array"`, giving every range one key.

`stringifyHavingValue()` now renders each shape by type, including a nested `Builder` from `having(Closure)`. Strings keep their previous space-to-underscore rewrite, so `havingRaw()` keys do not move.

## Part 2 — query parts that never reached the key

`make()` read the wheres, the havings, the columns, the orders, the limit and the offset. It read nothing else. Four parts were absent, and two of them returned another query's rows in an end-to-end probe:

| Part | Verified |
| --- | --- |
| `groupBy()` | Cached query returned 158 rows where the live query returns 5 |
| `union()` | Served the other union's rows |
| joins | Latent, and `leftJoin` against `join` shares tags too |
| `distinct()` | Latent |

Each now has a method: `getGroupByClauses()`, `getJoinClauses()`, `getUnionClauses()`, `getDistinctClause()`.

### The backstop

Enumeration is what has failed here repeatedly. #615 missed clause families, #616 missed clause types, and this issue is four query parts nobody had listed. Adding a fifth enumeration fixes today and says nothing about tomorrow.

`getUnkeyedQueryPropertiesSlug()` hashes every builder property that appears in neither `KEYED_QUERY_PROPERTIES` (what a named method writes) nor `UNKEYED_INFRASTRUCTURE_PROPERTIES` (connection plumbing). Today that covers `aggregate`, `indexHint`, `groupLimit`, `lock`, `unionLimit`, `unionOffset`, `unionOrders` and `afterQueryCallbacks`. Tomorrow it covers whatever Laravel adds, with no edit here.

It changes the failure mode. A property this class has never heard of now produces an **over-specific** key, which costs a cache miss, instead of a **shared** key, which returns wrong rows. Only non-empty values are hashed, so a builder in its default state adds nothing to the key.

Both lists are closed sets, so two tests pin them: one asserts their exact contents, and one asserts every name in them still exists on `Illuminate\Database\Query\Builder`. The second is what will speak up if Laravel renames a property.

## Part 3 — the binding cursor

`CacheKey` walks the where-binding array with a cursor, and each handler advances it by the bindings that clause consumed. Four handlers disagreed with what Laravel actually bound, so every later clause read the wrong slot.

| Clause | Was | Now |
| --- | --- | --- |
| `whereIntegerNotInRaw()` | named by no list, fell through to the generic single-binding path | named by the In family, consumes nothing |
| `whereIntegerInRaw()` | advanced by the value count | consumes nothing, because it binds nothing |
| binary-UUID `whereIn()` | returned before advancing | advances, then returns |
| `whereRowValues()`, `whereBetween()` | counted array elements | counts `cleanBindings()` |

`getInClauseBindingCount()` holds that rule in one place now, so the UUID branch and the main branch cannot drift apart again.

## Beyond the issue

Sweeping each class rather than each reported instance turned up three more:

- `havingRaw("total > ?", [5])` keeps its bindings in a channel of their own, so two calls differing only in a bound value built one key.
- `groupByRaw()` has the same shape and the same defect.
- `where("col", ">", new Expression(...))` binds nothing, but the cursor consumed a slot for it anyway.

## Test plan

- [x] Full suite green: **507 tests, 1289 assertions, 4 skipped**. Base `57009c4` is 465.
- [x] **15 mutations, all red.** Each fix reverted in turn, with the targeted test confirmed failing, then restored.
- [x] One dud test caught and rewritten. The `InRaw` test first stayed green under mutation, because the cursor ran off the end of the binding array and the literal-value fallback rebuilt the correct key by accident. It now carries four trailing clauses so the over-advanced cursor lands on a real binding belonging to another clause.
- [x] All eleven findings re-probed on this branch. Every pair now keys distinctly, and the empty `whereExists()` completes.
- [x] Pint delta zero on `src/CacheKey.php`: the same eight fixers as `master`, none added. New test files flag the same three as the existing `OrWhereTest.php`.
- [x] No doc drift. Nothing outside `CacheKey.php` references the changed signatures.

### Not verified locally

Everything above ran on PHP 8.5, Laravel 13, SQLite. The matrix spans PHP 8.2 to 8.5 across Laravel 11 to 13.

The backstop reads `get_object_vars()` on the query builder, and Laravel 11's builder carries a different property set from Laravel 13's. That is the piece most likely to behave differently across the matrix, which is why the two list-pinning tests exist. If something breaks on 11, start there.
