### PR TITLE
fix: 🐛 tag tables reached via whereHas/whereExists for cache invalidation

### DIFF
--- a/src/CacheTags.php
+++ b/src/CacheTags.php
@@ -5,6 +5,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
+use SplObjectStorage;
 use Throwable;
 
 class CacheTags
@@ -52,8 +53,10 @@ class CacheTags
             ->values();
 
         $joinTags = $this->getJoinTags();
+        $subqueryWhereTags = $this->getSubqueryWhereTags();
 
         return $tags->merge($joinTags)
+            ->merge($subqueryWhereTags)
             ->unique()
             ->values()
             ->toArray();
@@ -150,6 +153,93 @@ class CacheTags
         } catch (Throwable) {
             return [];
         }
+    }
+
+    /**
+     * Returns tags for tables reached via whereHas()/whereExists()-style
+     * subqueries (recursively, including nested ones).
+     */
+    protected function getSubqueryWhereTags() : array
+    {
+        $baseQuery = $this->query;
+
+        if (method_exists($this->query, 'getQuery')) {
+            $baseQuery = $this->query->getQuery();
+        }
+
+        if (! property_exists($baseQuery, 'wheres')) {
+            return [];
+        }
+
+        $prefix = $this->getCachePrefix();
+
+        return collect($this->getSubqueryTablesFromBuilder($baseQuery, new SplObjectStorage))
+            ->map(function ($table) use ($prefix) {
+                return $prefix . (new Str)->slug($table);
+            })
+            ->unique()
+            ->values()
+            ->toArray();
+    }
+
+    protected function getSubqueryTablesFromBuilder($builder, SplObjectStorage $seen) : array
+    {
+        if (! is_object($builder) || $seen->contains($builder)) {
+            return [];
+        }
+
+        $seen->attach($builder);
+
+        $tables = collect($builder->wheres ?? [])
+            ->merge($builder->havings ?? [])
+            ->flatMap(function ($where) use ($seen) {
+                return $this->getSubqueryTablesFromWhere($where, $seen);
+            })
+            ->toArray();
+
+        foreach ($builder->joins ?? [] as $join) {
+            foreach ($join->wheres ?? [] as $where) {
+                $tables = array_merge($tables, $this->getSubqueryTablesFromWhere($where, $seen));
+            }
+        }
+
+        foreach ($builder->unions ?? [] as $union) {
+            $unionQuery = $union['query'] ?? null;
+
+            if (is_object($unionQuery)) {
+                $tables = array_merge($tables, $this->getSubqueryTablesFromBuilder($unionQuery, $seen));
+            }
+        }
+
+        return $tables;
+    }
+
+    protected function getSubqueryTablesFromWhere(array $where, SplObjectStorage $seen) : array
+    {
+        $type = $where['type'] ?? null;
+
+        if (! in_array($type, ['Exists', 'NotExists', 'Nested', 'Sub'], true)) {
+            return [];
+        }
+
+        $query = $where['query'] ?? null;
+
+        if (! is_object($query)) {
+            return [];
+        }
+
+        $tables = [];
+        $from = $query->from ?? null;
+
+        if (is_string($from)) {
+            if (stripos($from, ' as ') !== false) {
+                $from = trim(explode(' as ', strtolower($from))[0]);
+            }
+
+            $tables[] = $from;
+        }
+
+        return array_merge($tables, $this->getSubqueryTablesFromBuilder($query, $seen));
     }
 
     protected function getRelatedModel($carry) : Model

--- a/tests/Integration/CachedBuilder/BooleanTest.php
+++ b/tests/Integration/CachedBuilder/BooleanTest.php
@@ -70,6 +70,7 @@ class BooleanTest extends IntegrationTestCase
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
         ];
 
         $expectedAuthor = Author::factory()->create(['is_famous' => false]);

--- a/tests/Integration/CachedBuilder/OrWhereTest.php
+++ b/tests/Integration/CachedBuilder/OrWhereTest.php
@@ -36,12 +36,12 @@ class OrWhereTest extends IntegrationTestCase
         ];
     }
 
-    private function assertFirstQueryWasCached($query, string $description) : void
+    private function assertFirstQueryWasCached($query, string $description, array $extraTags = []) : void
     {
         $key = sha1($this->cacheKey($query));
         $results = $query->get();
         $cached = $this->cache()
-            ->tags($this->bookTags())
+            ->tags([...$this->bookTags(), ...$extraTags])
             ->get($key);
 
         $this->assertNotNull(
@@ -163,7 +163,8 @@ class OrWhereTest extends IntegrationTestCase
                 ->whereHas("author", function ($query) {
                     $query->where("id", 2);
                 }),
-            "The whereHas-query"
+            "The whereHas-query",
+            ["genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors"]
         );
 
         $results = (new Book)

--- a/tests/Integration/CachedBuilder/WhereHasMorphTest.php
+++ b/tests/Integration/CachedBuilder/WhereHasMorphTest.php
@@ -21,6 +21,7 @@ class WhereHasMorphTest extends IntegrationTestCase
         $cacheResults = $this->cache()->tags([
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturescomment",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:posts",
         ])
             ->get(sha1(
                 "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-nested-or-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post-exists-comments.commentable_id_=_posts.id"
@@ -43,6 +44,7 @@ class WhereHasMorphTest extends IntegrationTestCase
         $cacheResults = $this->cache()->tags([
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturescomment",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:posts",
         ])
             ->get(sha1(
                 "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-nested-or-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post-exists-comments.commentable_id_=_posts.id-or-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedPost-exists-comments.commentable_id_=_posts.id"
@@ -69,6 +71,7 @@ class WhereHasMorphTest extends IntegrationTestCase
         $cacheResults = $this->cache()->tags([
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturescomment",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:posts",
         ])
             ->get(sha1(
                 "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:comments:genealabslaravelmodelcachingtestsfixturescomment-nested-or-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\Post-exists-comments.commentable_id_=_posts.id-subject_like_%25uncached post-or-nested-comments.commentable_type_=_GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedPost-exists-comments.commentable_id_=_posts.id-subject_like_%25uncached post"

--- a/tests/Integration/CachedBuilder/WhereHasTest.php
+++ b/tests/Integration/CachedBuilder/WhereHasTest.php
@@ -1,7 +1,9 @@
 <?php namespace GeneaLabs\LaravelModelCaching\Tests\Integration\CachedBuilder;
 
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Author;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Book;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\BookWithUncachedStore;
+use GeneaLabs\LaravelModelCaching\Tests\Fixtures\Profile;
 use GeneaLabs\LaravelModelCaching\Tests\Fixtures\UncachedAuthor;
 use GeneaLabs\LaravelModelCaching\Tests\IntegrationTestCase;
 
@@ -70,5 +72,46 @@ class WhereHasTest extends IntegrationTestCase
             ));
 
         $this->assertNull($results);
+    }
+
+    public function testWhereHasCacheIsBustedWhenRelatedTableIsWritten()
+    {
+        $author = Author::factory()->create(["name" => "John"]);
+        Book::factory()->create(["author_id" => $author->id]);
+
+        $query = fn () => (new Book)
+            ->whereHas("author", function ($query) {
+                $query->where("name", "John");
+            })
+            ->get();
+
+        $this->assertNotEmpty($query());
+
+        $author->name = "Jane";
+        $author->save();
+
+        $this->assertEmpty($query());
+    }
+
+    public function testNestedWhereHasCacheIsBustedWhenDeeplyRelatedTableIsWritten()
+    {
+        $author = Author::factory()->create(["name" => "John"]);
+        $profile = Profile::factory()->create(["author_id" => $author->id, "first_name" => "Alpha"]);
+        Book::factory()->create(["author_id" => $author->id]);
+
+        $query = fn () => (new Book)
+            ->whereHas("author", function ($query) {
+                $query->whereHas("profile", function ($query) {
+                    $query->where("first_name", "Alpha");
+                });
+            })
+            ->get();
+
+        $this->assertNotEmpty($query());
+
+        $profile->first_name = "Beta";
+        $profile->save();
+
+        $this->assertEmpty($query());
     }
 }

--- a/tests/Integration/CachedBuilderRelationshipsTest.php
+++ b/tests/Integration/CachedBuilderRelationshipsTest.php
@@ -17,6 +17,7 @@ class CachedBuilderRelationshipsTest extends IntegrationTestCase
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesstore",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:stores",
         ];
         $cachedResults = $this
             ->cache()

--- a/tests/Integration/CachedBuilderTest.php
+++ b/tests/Integration/CachedBuilderTest.php
@@ -512,6 +512,7 @@ class CachedBuilderTest extends IntegrationTestCase
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
         ];
 
         $cachedResults = $this->cache()
@@ -534,6 +535,7 @@ class CachedBuilderTest extends IntegrationTestCase
         $tags = [
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
         ];
 
         $cachedResults = $this->cache()

--- a/tests/Integration/CachedModelTest.php
+++ b/tests/Integration/CachedModelTest.php
@@ -122,6 +122,7 @@ class CachedModelTest extends IntegrationTestCase
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesbook",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:genealabslaravelmodelcachingtestsfixturesauthor",
             "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:books",
+            "genealabs:laravel-model-caching:testing:{$this->testingSqlitePath}testing.sqlite:authors",
         ];
 
         $cachedResults = $this


### PR DESCRIPTION
## What problem does this solve?

Writing to a table only reached through `whereHas()`/`whereExists()` never busted the cache of a query that depended on it, so it kept serving stale results forever.

## What changed, and why this way

`CacheTags::make()` only found related tables by walking real SQL joins (`getJoinTags()`, which reads `$baseQuery->joins`). `whereHas()`/`whereExists()` don't produce a join, they produce an "Exists"/"NotExists" where-clause carrying its own inner query builder, sitting in `$baseQuery->wheres` instead. `getJoinTags()` never looked there.

Reproduced it directly before writing any fix: `Book::whereHas('author', fn ($q) => $q->where('name', 'John'))` tagged only book/books no authors tag. Cached it, renamed the matching author, ran the same query again and it kept returning the stale book.

Fix walks wheres (+ havings, each join's own nested wheres, and unions) recursively, and for Exists/NotExists/Nested/Sub where-types, tags the table the inner query reads from, then recurses into that inner query for further nesting (a `whereHas` nested inside another `whereHas` still gets caught). This reuses the same idea the file already applies to join-based tables (`getJoinTags()`/`getDeferredJoinedSubqueryTables()`), just for this other where-clause shape, rather than inventing a new mechanism.

I did consider whether `whereIn()`/`whereNotIn()` subqueries have the same problem, they do, verified the same way, but that's a different root cause (Laravel compiles those straight to a raw Expression and discards the query builder, so there's no `$where['query']` to walk) and needs its own fix. Left out of this PR on purpose.

## Test plan

- [x] The existing suite still passes.
- [x] New behaviour has a test, or the fix has a regression test that fails without it (`testWhereHasCacheIsBustedWhenRelatedTableIsWritten` and `testNestedWhereHasCacheIsBustedWhenDeeplyRelatedTableIsWritten`, both in `WhereHasTest.php`).
- [x] Each new test was checked against the unfixed code and confirmed to fail there.

8 pre-existing tests also needed their hardcoded expected-tags lists updated (`BooleanTest`, `WhereHasMorphTest` x3, `CachedBuilderRelationshipsTest`, `CachedBuilderTest` x2, `CachedModelTest`, `OrWhereTest`). Each does a direct cache lookup against an exact tag list, and this fix correctly adds one more tag to those same queries, so the old lists were just out of date, not wrong to have been written that way originally.

## Anything a reviewer should know

Cache tags change for any query using `whereHas()`/`whereExists()`/`whereHasMorph()`/`has()`/`doesntHave()` (or nesting one inside another), not the cache key itself, but the tag set used for invalidation. Every such query reads cold once after this ships, same as the note in #621 about grouped/joined queries.
